### PR TITLE
Feature/on frame captured callback

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,11 @@
 
 ## develop
 
+### CHANGE
+
+- onByteBufferFrameCaptured が onFrameCaptured が置き換えられた変更に対応した
+  - cf. https://webrtc-review.googlesource.com/c/src/+/43022
+
 ## 1.5.1
 
 ### UPDATE

--- a/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/CapturerObserverProxy.java
+++ b/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/CapturerObserverProxy.java
@@ -12,28 +12,22 @@ import org.webrtc.YuvHelper;
 import java.nio.ByteBuffer;
 
 public class CapturerObserverProxy implements VideoCapturer.CapturerObserver {
-
     public static final String TAG = CapturerObserverProxy.class.getSimpleName();
 
     private VideoCapturer.CapturerObserver originalObserver;
-    private SurfaceTextureHelper surfaceTextureHelper;
     private RTCVideoEffector videoEffector;
 
     public CapturerObserverProxy(final SurfaceTextureHelper surfaceTextureHelper,
                                  VideoCapturer.CapturerObserver observer,
                                  RTCVideoEffector effector) {
 
-        this.surfaceTextureHelper = surfaceTextureHelper;
         this.originalObserver = observer;
         this.videoEffector = effector;
 
-        final Handler handler = this.surfaceTextureHelper.getHandler();
-        ThreadUtils.invokeAtFrontUninterruptibly(handler, new Runnable() {
-            @Override
-            public void run() {
-                videoEffector.init(surfaceTextureHelper);
-            }
-        });
+        final Handler handler = surfaceTextureHelper.getHandler();
+        ThreadUtils.invokeAtFrontUninterruptibly(handler, () ->
+                videoEffector.init(surfaceTextureHelper)
+        );
     }
 
     @Override
@@ -49,50 +43,54 @@ public class CapturerObserverProxy implements VideoCapturer.CapturerObserver {
     @Override
     public void onFrameCaptured(VideoFrame frame) {
         if (this.videoEffector.needToProcessFrame()) {
-            final VideoFrame.I420Buffer buffer = frame.getBuffer().toI420();
+            // TODO(shino): libwebrtc 66.8.1, Android 7.0/Xperia Z4 では frame.getBuffer() は
+            // org.webrtc.NV21Buffer で実装されている。
+            // NV21Buffer には private data :: byte[] があるがアクセスは出来ない。
+            // VideoEffectorLogger.d(TAG, "frame.getBuffer: " + frame.getBuffer());
+
+            final VideoFrame.I420Buffer i420Buffer = frame.getBuffer().toI420();
+            // TODO: JavaI420Buffer は direct ByteBuffer を3つ別に持っている。
+            // それらが一直線かどうかは不明。実装次第だが toI420 でメモリコピーは不要。
+            // VideoEffectorLogger.d(TAG, "frame.getBuffer() = " + frame.getBuffer());
+            // VideoEffectorLogger.d(TAG, "i420Buffer = " + i420Buffer);
             frame.release();
 
-            final int height = buffer.getHeight();
-            final int width = buffer.getWidth();
-            final int strideY = buffer.getStrideY();
-            final int strideU = buffer.getStrideU();
-            final int strideV = buffer.getStrideV();
+            final int height = i420Buffer.getHeight();
+            final int width = i420Buffer.getWidth();
+            final int strideY = i420Buffer.getStrideY();
+            final int strideU = i420Buffer.getStrideU();
+            final int strideV = i420Buffer.getStrideV();
 
             final int chromaWidth = (width + 1) / 2;
             final int chromaHeight = (height + 1) / 2;
             final int dstSize = width * height + chromaWidth * chromaHeight * 2;
             ByteBuffer dst = ByteBuffer.allocateDirect(dstSize);
-            // TODO: libyuv に I420ToARGB があるので NV12 に変換する必要はないかもしれなが、
-            //       下回りの byte[] を取得する方法がわからない
-            YuvHelper.I420ToNV12(buffer.getDataY(), strideY, buffer.getDataU(), strideU,
-                    buffer.getDataV(), strideV, dst, width, height);
-            buffer.release();
+            // TODO: libyuv には I420ToARGB があるので NV12 に変換する必要はないかもしれない。
+            //       そもそも i420Buffer の byte[] が一直線の保証はないし、
+            //       下回りの byte[] を取得する方法も無い
+            YuvHelper.I420ToNV12(i420Buffer.getDataY(), strideY,
+                    i420Buffer.getDataU(), strideU,
+                    i420Buffer.getDataV(), strideV,
+                    dst, width, height);
+            i420Buffer.release();
 
-            byte[] filteredBytes =
+            byte[] effectedBytes =
                     this.videoEffector.processByteBufferFrame(dst.array(), width, height,
                             frame.getRotation(), frame.getTimestampNs());
 
             final int offsetY = 0;
             final int lengthY = strideY * height;
-            VideoEffectorLogger.d(TAG, "lengthY = " + lengthY);
             final int offsetU = offsetY + lengthY;
             final int lengthU = strideU * chromaHeight;
             final int offsetV = offsetU + lengthU;
             final int lengthV = strideV * chromaHeight;
 
-            final ByteBuffer dataY = ByteBuffer.allocateDirect(lengthY);
-            dataY.mark();
-            dataY.put(filteredBytes, offsetY, lengthY);
-            dataY.reset();
-            final ByteBuffer dataU = ByteBuffer.allocateDirect(lengthU);
-            dataU.mark();
-            dataU.put(filteredBytes, offsetU, lengthU);
-            dataU.reset();
-            final ByteBuffer dataV = ByteBuffer.allocateDirect(lengthV);
-            dataV.mark();
-            dataV.put(filteredBytes, offsetV, lengthV);
-            dataV.reset();
-
+            // JavaI420Buffer.wrap には direct ByteBuffer を渡す必要がある。
+            // VideoEffector#processByteBufferFrame の IN/OUT を ByteBuffer にすると
+            // ミスマッチが減りそう。
+            final ByteBuffer dataY = copy(effectedBytes, offsetY, lengthY);
+            final ByteBuffer dataU = copy(effectedBytes, offsetU, lengthU);
+            final ByteBuffer dataV = copy(effectedBytes, offsetV, lengthV);
             VideoFrame.I420Buffer filteredBuffer = JavaI420Buffer.wrap(
                     width, height,
                     dataY, strideY, dataU, strideU, dataV, strideV,
@@ -105,5 +103,13 @@ public class CapturerObserverProxy implements VideoCapturer.CapturerObserver {
         } else {
             this.originalObserver.onFrameCaptured(frame);
         }
+    }
+
+    private ByteBuffer copy(byte[] src, int offset, int length) {
+        ByteBuffer data = ByteBuffer.allocateDirect(length);
+        data.mark();
+        data.put(src, offset, length);
+        data.reset();
+        return data;
     }
 }

--- a/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/CapturerObserverProxy.java
+++ b/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/CapturerObserverProxy.java
@@ -47,37 +47,6 @@ public class CapturerObserverProxy implements VideoCapturer.CapturerObserver {
     }
 
     @Override
-    public void onByteBufferFrameCaptured(byte[] bytes, int width, int height,
-                                          int rotation, long timestamp) {
-
-        if (this.videoEffector.needToProcessFrame()) {
-
-            byte[] filteredBytes =
-                    this.videoEffector.processByteBufferFrame(bytes, width, height,
-                            rotation, timestamp);
-
-            this.originalObserver.onByteBufferFrameCaptured(filteredBytes, width, height,
-                    rotation, timestamp);
-            surfaceTextureHelper.returnTextureFrame();
-
-        } else {
-
-            this.originalObserver.onByteBufferFrameCaptured(bytes, width, height,
-                    rotation, timestamp);
-
-        }
-    }
-
-    @Override
-    public void onTextureFrameCaptured(int width, int height, int oesTextureId,
-                                       float[] transformMatrix, int rotation, long timestamp) {
-
-        this.originalObserver.onTextureFrameCaptured(width, height, oesTextureId,
-                transformMatrix, rotation, timestamp);
-
-    }
-
-    @Override
     public void onFrameCaptured(VideoFrame frame) {
         if (this.videoEffector.needToProcessFrame()) {
             final VideoFrame.I420Buffer buffer = frame.getBuffer().toI420();

--- a/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/RTCVideoEffector.java
+++ b/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/RTCVideoEffector.java
@@ -139,16 +139,13 @@ public class RTCVideoEffector {
     }
 
     public void dispose() {
-        if (helper != null) {
+        if (this.helper != null) {
             // This effector is not initialized
             return;
         }
-        ThreadUtils.invokeAtFrontUninterruptibly(this.helper.getHandler(), new Runnable() {
-            @Override
-            public void run() {
-                disposeInternal();
-            }
-        });
+        ThreadUtils.invokeAtFrontUninterruptibly(this.helper.getHandler(), () ->
+                disposeInternal()
+        );
     }
 
     private void disposeInternal() {


### PR DESCRIPTION
libwebrtc で frame capture 時のコールバックが変わった [1] ことにたいする対応

つまづきポイント

- これまでは一直線の byte[] での受け渡しだったが、
- VideoFrame という webrtc の API クラスに変わった
- フィルターは(一部) android-gpuimage ライブラリに投げているがそっちは byte[] で受け取る
- メモリコピーが結構走ってそう
  - VideoFrame に戻すところでは明らかにコピーしている
    (buffer を3分割した direct buffers が必要なのだがどうすればいいのか)
  - YuvHelper.I420ToNV12 の中はどうか
- メモリお掃除がひつようなのか?

TODO
- android-gpuimage の他の口も探す
- このレイヤでやるのが正しいのか、VideoSink とか SurfaceViewRenderer とかは?(理解せずに書いている)

[1] https://webrtc-review.googlesource.com/c/src/+/43022

```
commit 682dc619f29453a5cbe849380f726bb16de3a6cf
Author: Sami Kalliomäki <sakal@webrtc.org>
Date:   Fri Jan 26 11:06:45 2018 +0100

    Conclude VideoFrame emit fieldtrial.

    Concludes VideoFrame emit fieldtrial and start producing VideoFrames
    by default. Deprecates old onByteBufferFrameCaptured and
    onTextureFrameCaptured methods.

    Bug: webrtc:8776
    Change-Id: Icc224e9f8d89a30f04cf95dd46a498d69cffe9d0
    Reviewed-on: https://webrtc-review.googlesource.com/43022
    Commit-Queue: Sami Kalliomäki <sakal@webrtc.org>
    Reviewed-by: Anders Carlsson <andersc@webrtc.org>
    Cr-Commit-Position: refs/heads/master@{#21866}
```