### PR TITLE
YUV から RGB への変換がずれていた問題を修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,19 @@
 
 ## develop
 
+### ADD
+
+- Effected video chat にセピア化のエフェクトを追加した
+  - Thanks to @daneko
+- Effected video chat にデバッグ、比較用としてなにもしないエフェクトを追加した
+  - Thanks to @daneko
+
+### FIX
+
+- Effected video chat で I420 から変換された RGB データがずれていた問題を修正した
+  - これに伴い、NV12/NV21 の経由を廃止し、I420 と RGBA の直接の相互変換とした
+  - Thanks to @daneko
+
 ## 1.7.1
 
 ### ADD

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/EffectedVideoChatActivity.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/EffectedVideoChatActivity.kt
@@ -93,6 +93,13 @@ class EffectedVideoChatActivity : AppCompatActivity() {
                 "EMBOSS" -> {
                     addGPUImageFilter(GPUImageEmbossFilter())
                 }
+                "SEPIA" -> {
+                    addGPUImageFilter(GPUImageSepiaFilter())
+                }
+                "NONE" -> {
+                    // For Debug
+                    addGPUImageFilter(GPUImageFilter())
+                }
                 else -> {}
             }
 

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/EffectedVideoChatSetupActivity.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/EffectedVideoChatSetupActivity.kt
@@ -30,7 +30,8 @@ class EffectedVideoChatSetupActivity : AppCompatActivity() {
     private var channelNameInput: EditText? = null
     private var effectSpinner:    MaterialSpinner? = null
 
-    val effectOptions = listOf("GRAYSCALE", "PIXELATION", "POSTERIZE", "TOON", "HALFTONE", "HUE", "EMBOSS")
+    val effectOptions = listOf("GRAYSCALE", "PIXELATION", "POSTERIZE", "TOON",
+            "HALFTONE", "HUE", "EMBOSS", "SEPIA", "NONE")
 
     private fun setupUI() {
 

--- a/webrtc-video-effector/src/main/cpp/yuvconv.c
+++ b/webrtc-video-effector/src/main/cpp/yuvconv.c
@@ -9,12 +9,12 @@ Java_jp_shiguredo_webrtc_video_effector_format_LibYuvBridge_i420ToAbgrInternal(
     jobject dataUBuffer, jint strideU,
     jobject dataVBuffer, jint strideV,
     jint width, jint height,
-    jbyteArray outRgba)
+    jobject outRgbaBuffer)
 {
     uint8_t *data_y = (uint8_t*) (*env)->GetDirectBufferAddress(env, dataYBuffer);
     uint8_t *data_u = (uint8_t*) (*env)->GetDirectBufferAddress(env, dataUBuffer);
     uint8_t *data_v = (uint8_t*) (*env)->GetDirectBufferAddress(env, dataVBuffer);
-    uint8_t *dst_rgba = (uint8_t *)((*env)->GetDirectBufferAddress(env, outRgba));
+    uint8_t *out_rgba = (uint8_t *)((*env)->GetDirectBufferAddress(env, outRgbaBuffer));
 
     int stride_y = strideY;
     int stride_u = strideU;
@@ -40,7 +40,7 @@ Java_jp_shiguredo_webrtc_video_effector_format_LibYuvBridge_i420ToAbgrInternal(
     I420ToABGR(data_y, stride_y,
                data_u, stride_u,
                data_v, stride_v,
-               dst_rgba, dst_stride_rgba,
+               out_rgba, dst_stride_rgba,
                src_width, src_height);
 }
 
@@ -48,20 +48,20 @@ JNIEXPORT void JNICALL
 Java_jp_shiguredo_webrtc_video_effector_format_LibYuvBridge_abgrToI420Internal(
         JNIEnv *env,
         jobject obj,
-        jbyteArray rgbaArray,
+        jobject rgbaBuffer,
         jint width,
         jint height,
-        jbyteArray dataYArray,
+        jobject outDataYBuffer,
         jint strideY,
-        jbyteArray dataUArray,
+        jobject outDataUBuffer,
         jint strideU,
-        jbyteArray dataVArray,
+        jobject outDataVBuffer,
         jint strideV)
 {
-    jbyte *rgba = (jbyte*) (*env)->GetPrimitiveArrayCritical(env, rgbaArray, 0);
-    jbyte *data_y = (jbyte*) (*env)->GetPrimitiveArrayCritical(env, dataYArray, 0);
-    jbyte *data_u = (jbyte*) (*env)->GetPrimitiveArrayCritical(env, dataUArray, 0);
-    jbyte *data_v = (jbyte*) (*env)->GetPrimitiveArrayCritical(env, dataVArray, 0);
+    uint8_t *rgba = (uint8_t*) (*env)->GetDirectBufferAddress(env, rgbaBuffer);
+    uint8_t *out_data_y = (uint8_t*) (*env)->GetDirectBufferAddress(env, outDataYBuffer);
+    uint8_t *out_data_u = (uint8_t*) (*env)->GetDirectBufferAddress(env, outDataUBuffer);
+    uint8_t *out_data_v = (uint8_t*) (*env)->GetDirectBufferAddress(env, outDataVBuffer);
 
     /*
     // ABGR little endian (rgba in memory) to I420.
@@ -73,13 +73,8 @@ Java_jp_shiguredo_webrtc_video_effector_format_LibYuvBridge_abgrToI420Internal(
                    int width, int height);
     */
     ABGRToI420((uint8*) rgba, width * 4,
-               (uint8*) data_y, strideY,
-               (uint8*) data_u, strideU,
-               (uint8*) data_v, strideV,
+               (uint8*) out_data_y, strideY,
+               (uint8*) out_data_u, strideU,
+               (uint8*) out_data_v, strideV,
                width, height);
-
-    (*env)->ReleasePrimitiveArrayCritical(env, rgbaArray, rgba, 0);
-    (*env)->ReleasePrimitiveArrayCritical(env, dataYArray, data_y, 0);
-    (*env)->ReleasePrimitiveArrayCritical(env, dataUArray, data_u, 0);
-    (*env)->ReleasePrimitiveArrayCritical(env, dataVArray, data_v, 0);
 }

--- a/webrtc-video-effector/src/main/cpp/yuvconv.c
+++ b/webrtc-video-effector/src/main/cpp/yuvconv.c
@@ -5,8 +5,10 @@ JNIEXPORT void JNICALL
 Java_jp_shiguredo_webrtc_video_effector_format_LibYuvBridge_i420ToRgbaInternal(
     JNIEnv *env,
     jobject obj,
-    jbyteArray dataY, jint strideY, jbyteArray dataU, jint strideU,
-    jbyteArray dataV, jint strideV, jint width, jint height,
+    jbyteArray dataY, jint strideY,
+    jbyteArray dataU, jint strideU,
+    jbyteArray dataV, jint strideV,
+    jint width, jint height,
     jbyteArray outRgba)
 {
     uint8_t *dst_rgba = (uint8_t *)((*env)->GetPrimitiveArrayCritical(env, outRgba, 0));
@@ -22,9 +24,19 @@ Java_jp_shiguredo_webrtc_video_effector_format_LibYuvBridge_i420ToRgbaInternal(
     int src_width = width;
     int src_height = height;
 
-    I420ToRGBA(data_y, stride_y, data_u, stride_u,
+    /*
+    LIBYUV_API
+    int I420ToARGB(const uint8* src_y, int src_stride_y,
+                   const uint8* src_u, int src_stride_u,
+                   const uint8* src_v, int src_stride_v,
+                   uint8* dst_argb, int dst_stride_argb,
+                   int width, int height);
+    */
+    I420ToRGBA(data_y, stride_y,
+               data_u, stride_u,
                data_v, stride_v,
-               dst_rgba, dst_stride_rgba, src_width, src_height);
+               dst_rgba, dst_stride_rgba,
+               src_width, src_height);
 
     (*env)->ReleasePrimitiveArrayCritical(env, outRgba, dst_rgba, 0);
     (*env)->ReleasePrimitiveArrayCritical(env, dataY, data_y, 0);
@@ -51,8 +63,8 @@ Java_jp_shiguredo_webrtc_video_effector_format_LibYuvBridge_rgbaToI420Internal(
     jbyte *data_u = (jbyte*) (*env)->GetPrimitiveArrayCritical(env, dataUArray, 0);
     jbyte *data_v = (jbyte*) (*env)->GetPrimitiveArrayCritical(env, dataVArray, 0);
 
-    // ABGR little endian (rgba in memory) to I420.
     /*
+    // ABGR little endian (rgba in memory) to I420.
     LIBYUV_API
     int ABGRToI420(const uint8* src_frame, int src_stride_frame,
                    uint8* dst_y, int dst_stride_y,
@@ -60,15 +72,24 @@ Java_jp_shiguredo_webrtc_video_effector_format_LibYuvBridge_rgbaToI420Internal(
                    uint8* dst_v, int dst_stride_v,
                    int width, int height);
 
+// ARGB little endian (bgra in memory) to I420.
     LIBYUV_API
     int ARGBToI420(const uint8* src_argb, int src_stride_argb,
                    uint8* dst_y, int dst_stride_y,
                    uint8* dst_u, int dst_stride_u,
                    uint8* dst_v, int dst_stride_v,
                    int width, int height);
+
+    // RGBA little endian (abgr in memory) to I420.
+    LIBYUV_API
+    int RGBAToI420(const uint8* src_frame, int src_stride_frame,
+                   uint8* dst_y, int dst_stride_y,
+                   uint8* dst_u, int dst_stride_u,
+                   uint8* dst_v, int dst_stride_v,
+                   int width, int height);
     */
 
-    ABGRToI420((uint8*) rgba, width * 4,
+    RGBAToI420((uint8*) rgba, width * 4,
                (uint8*) data_y, strideY,
                (uint8*) data_u, strideU,
                (uint8*) data_v, strideV,

--- a/webrtc-video-effector/src/main/cpp/yuvconv.c
+++ b/webrtc-video-effector/src/main/cpp/yuvconv.c
@@ -72,9 +72,9 @@ Java_jp_shiguredo_webrtc_video_effector_format_LibYuvBridge_abgrToI420Internal(
                    uint8* dst_v, int dst_stride_v,
                    int width, int height);
     */
-    ABGRToI420((uint8*) rgba, width * 4,
-               (uint8*) out_data_y, strideY,
-               (uint8*) out_data_u, strideU,
-               (uint8*) out_data_v, strideV,
+    ABGRToI420(rgba, width * 4,
+               out_data_y, strideY,
+               out_data_u, strideU,
+               out_data_v, strideV,
                width, height);
 }

--- a/webrtc-video-effector/src/main/cpp/yuvconv.c
+++ b/webrtc-video-effector/src/main/cpp/yuvconv.c
@@ -14,8 +14,7 @@ Java_jp_shiguredo_webrtc_video_effector_format_LibYuvBridge_i420ToAbgrInternal(
     uint8_t *data_y = (uint8_t*) (*env)->GetDirectBufferAddress(env, dataYBuffer);
     uint8_t *data_u = (uint8_t*) (*env)->GetDirectBufferAddress(env, dataUBuffer);
     uint8_t *data_v = (uint8_t*) (*env)->GetDirectBufferAddress(env, dataVBuffer);
-
-    uint8_t *dst_rgba = (uint8_t *)((*env)->GetPrimitiveArrayCritical(env, outRgba, 0));
+    uint8_t *dst_rgba = (uint8_t *)((*env)->GetDirectBufferAddress(env, outRgba));
 
     int stride_y = strideY;
     int stride_u = strideU;
@@ -43,8 +42,6 @@ Java_jp_shiguredo_webrtc_video_effector_format_LibYuvBridge_i420ToAbgrInternal(
                data_v, stride_v,
                dst_rgba, dst_stride_rgba,
                src_width, src_height);
-
-    (*env)->ReleasePrimitiveArrayCritical(env, outRgba, dst_rgba, 0);
 }
 
 JNIEXPORT void JNICALL

--- a/webrtc-video-effector/src/main/cpp/yuvconv.c
+++ b/webrtc-video-effector/src/main/cpp/yuvconv.c
@@ -5,16 +5,17 @@ JNIEXPORT void JNICALL
 Java_jp_shiguredo_webrtc_video_effector_format_LibYuvBridge_i420ToAbgrInternal(
     JNIEnv *env,
     jobject obj,
-    jbyteArray dataY, jint strideY,
-    jbyteArray dataU, jint strideU,
-    jbyteArray dataV, jint strideV,
+    jobject dataYBuffer, jint strideY,
+    jobject dataUBuffer, jint strideU,
+    jobject dataVBuffer, jint strideV,
     jint width, jint height,
     jbyteArray outRgba)
 {
+    uint8_t *data_y = (uint8_t*) (*env)->GetDirectBufferAddress(env, dataYBuffer);
+    uint8_t *data_u = (uint8_t*) (*env)->GetDirectBufferAddress(env, dataUBuffer);
+    uint8_t *data_v = (uint8_t*) (*env)->GetDirectBufferAddress(env, dataVBuffer);
+
     uint8_t *dst_rgba = (uint8_t *)((*env)->GetPrimitiveArrayCritical(env, outRgba, 0));
-    uint8_t *data_y = (uint8_t*) (*env)->GetPrimitiveArrayCritical(env, dataY, 0);
-    uint8_t *data_u = (uint8_t*) (*env)->GetPrimitiveArrayCritical(env, dataU, 0);
-    uint8_t *data_v = (uint8_t*) (*env)->GetPrimitiveArrayCritical(env, dataV, 0);
 
     int stride_y = strideY;
     int stride_u = strideU;
@@ -44,9 +45,6 @@ Java_jp_shiguredo_webrtc_video_effector_format_LibYuvBridge_i420ToAbgrInternal(
                src_width, src_height);
 
     (*env)->ReleasePrimitiveArrayCritical(env, outRgba, dst_rgba, 0);
-    (*env)->ReleasePrimitiveArrayCritical(env, dataY, data_y, 0);
-    (*env)->ReleasePrimitiveArrayCritical(env, dataU, data_u, 0);
-    (*env)->ReleasePrimitiveArrayCritical(env, dataV, data_v, 0);
 }
 
 JNIEXPORT void JNICALL

--- a/webrtc-video-effector/src/main/cpp/yuvconv.c
+++ b/webrtc-video-effector/src/main/cpp/yuvconv.c
@@ -2,7 +2,7 @@
 #include "libyuv.h"
 
 JNIEXPORT void JNICALL
-Java_jp_shiguredo_webrtc_video_effector_format_LibYuvBridge_i420ToRgbaInternal(
+Java_jp_shiguredo_webrtc_video_effector_format_LibYuvBridge_i420ToAbgrInternal(
     JNIEnv *env,
     jobject obj,
     jbyteArray dataY, jint strideY,
@@ -26,13 +26,18 @@ Java_jp_shiguredo_webrtc_video_effector_format_LibYuvBridge_i420ToRgbaInternal(
 
     /*
     LIBYUV_API
-    int I420ToARGB(const uint8* src_y, int src_stride_y,
-                   const uint8* src_u, int src_stride_u,
-                   const uint8* src_v, int src_stride_v,
-                   uint8* dst_argb, int dst_stride_argb,
-                   int width, int height);
+    int I420ToABGR(const uint8_t* src_y,
+                   int src_stride_y,
+                   const uint8_t* src_u,
+                   int src_stride_u,
+                   const uint8_t* src_v,
+                   int src_stride_v,
+                   uint8_t* dst_abgr,
+                   int dst_stride_abgr,
+                   int width,
+                   int height);
     */
-    I420ToRGBA(data_y, stride_y,
+    I420ToABGR(data_y, stride_y,
                data_u, stride_u,
                data_v, stride_v,
                dst_rgba, dst_stride_rgba,
@@ -45,7 +50,7 @@ Java_jp_shiguredo_webrtc_video_effector_format_LibYuvBridge_i420ToRgbaInternal(
 }
 
 JNIEXPORT void JNICALL
-Java_jp_shiguredo_webrtc_video_effector_format_LibYuvBridge_rgbaToI420Internal(
+Java_jp_shiguredo_webrtc_video_effector_format_LibYuvBridge_abgrToI420Internal(
         JNIEnv *env,
         jobject obj,
         jbyteArray rgbaArray,
@@ -71,25 +76,8 @@ Java_jp_shiguredo_webrtc_video_effector_format_LibYuvBridge_rgbaToI420Internal(
                    uint8* dst_u, int dst_stride_u,
                    uint8* dst_v, int dst_stride_v,
                    int width, int height);
-
-// ARGB little endian (bgra in memory) to I420.
-    LIBYUV_API
-    int ARGBToI420(const uint8* src_argb, int src_stride_argb,
-                   uint8* dst_y, int dst_stride_y,
-                   uint8* dst_u, int dst_stride_u,
-                   uint8* dst_v, int dst_stride_v,
-                   int width, int height);
-
-    // RGBA little endian (abgr in memory) to I420.
-    LIBYUV_API
-    int RGBAToI420(const uint8* src_frame, int src_stride_frame,
-                   uint8* dst_y, int dst_stride_y,
-                   uint8* dst_u, int dst_stride_u,
-                   uint8* dst_v, int dst_stride_v,
-                   int width, int height);
     */
-
-    RGBAToI420((uint8*) rgba, width * 4,
+    ABGRToI420((uint8*) rgba, width * 4,
                (uint8*) data_y, strideY,
                (uint8*) data_u, strideU,
                (uint8*) data_v, strideV,

--- a/webrtc-video-effector/src/main/cpp/yuvconv.c
+++ b/webrtc-video-effector/src/main/cpp/yuvconv.c
@@ -2,34 +2,34 @@
 #include "libyuv.h"
 
 JNIEXPORT void JNICALL
-Java_jp_shiguredo_webrtc_video_effector_format_LibYuvBridge_yuvToRgbaInternal(
+Java_jp_shiguredo_webrtc_video_effector_format_LibYuvBridge_i420ToRgbaInternal(
     JNIEnv *env,
     jobject obj,
-    jbyteArray inYuvBytes,
-    jint width,
-    jint height,
-    jbyteArray outRgbaBytes)
+    jbyteArray dataY, jint strideY, jbyteArray dataU, jint strideU,
+    jbyteArray dataV, jint strideV, jint width, jint height,
+    jbyteArray outRgba)
 {
-  uint8_t *rgbData = (uint8_t *)((*env)->GetPrimitiveArrayCritical(env, outRgbaBytes, 0));
-  uint8_t *yuv = (uint8_t*) (*env)->GetPrimitiveArrayCritical(env, inYuvBytes, 0);
+    uint8_t *dst_rgba = (uint8_t *)((*env)->GetPrimitiveArrayCritical(env, outRgba, 0));
+    uint8_t *data_y = (uint8_t*) (*env)->GetPrimitiveArrayCritical(env, dataY, 0);
+    uint8_t *data_u = (uint8_t*) (*env)->GetPrimitiveArrayCritical(env, dataU, 0);
+    uint8_t *data_v = (uint8_t*) (*env)->GetPrimitiveArrayCritical(env, dataV, 0);
 
-  const uint8* src_y = yuv;
-  int src_stride_y = width;
-  const uint8* src_vu = src_y + width * height;
-  int src_stride_vu = (width + 1) / 2 * 2;;
-  int dst_stride_argb = width * 4;
+    int stride_y = strideY;
+    int stride_u = strideU;
+    int stride_v = strideV;
 
-    NV12ToARGB(src_y,
-         src_stride_y,
-         src_vu,
-         src_stride_vu,
-         rgbData,
-         dst_stride_argb,
-         width,
-         height);
+    int dst_stride_rgba = width * 4;
+    int src_width = width;
+    int src_height = height;
 
-  (*env)->ReleasePrimitiveArrayCritical(env, outRgbaBytes, rgbData, 0);
-  (*env)->ReleasePrimitiveArrayCritical(env, inYuvBytes, yuv, 0);
+    I420ToRGBA(data_y, stride_y, data_u, stride_u,
+               data_v, stride_v,
+               dst_rgba, dst_stride_rgba, src_width, src_height);
+
+    (*env)->ReleasePrimitiveArrayCritical(env, outRgba, dst_rgba, 0);
+    (*env)->ReleasePrimitiveArrayCritical(env, dataY, data_y, 0);
+    (*env)->ReleasePrimitiveArrayCritical(env, dataU, data_u, 0);
+    (*env)->ReleasePrimitiveArrayCritical(env, dataV, data_v, 0);
 }
 
 // most of this code is borrowed from

--- a/webrtc-video-effector/src/main/cpp/yuvconv.c
+++ b/webrtc-video-effector/src/main/cpp/yuvconv.c
@@ -8,7 +8,7 @@ Java_jp_shiguredo_webrtc_video_effector_format_LibYuvBridge_yuvToRgbaInternal(
     jbyteArray inYuvBytes,
     jint width,
     jint height,
-    jintArray outRgbaBytes)
+    jbyteArray outRgbaBytes)
 {
   uint8_t *rgbData = (uint8_t *)((*env)->GetPrimitiveArrayCritical(env, outRgbaBytes, 0));
   uint8_t *yuv = (uint8_t*) (*env)->GetPrimitiveArrayCritical(env, inYuvBytes, 0);

--- a/webrtc-video-effector/src/main/cpp/yuvconv.c
+++ b/webrtc-video-effector/src/main/cpp/yuvconv.c
@@ -32,40 +32,50 @@ Java_jp_shiguredo_webrtc_video_effector_format_LibYuvBridge_i420ToRgbaInternal(
     (*env)->ReleasePrimitiveArrayCritical(env, dataV, data_v, 0);
 }
 
-// most of this code is borrowed from
-// https://github.com/alzybaad/RGB2YUV/
 JNIEXPORT void JNICALL
-Java_jp_shiguredo_webrtc_video_effector_format_LibYuvBridge_rgbToBgrInternal(
+Java_jp_shiguredo_webrtc_video_effector_format_LibYuvBridge_rgbaToI420Internal(
         JNIEnv *env,
         jobject obj,
-        jbyteArray rgbArray,
+        jbyteArray rgbaArray,
         jint width,
         jint height,
-        jbyteArray bgrArray)
+        jbyteArray dataYArray,
+        jint strideY,
+        jbyteArray dataUArray,
+        jint strideU,
+        jbyteArray dataVArray,
+        jint strideV)
 {
-    jbyte *rgb = (jbyte*) (*env)->GetPrimitiveArrayCritical(env, rgbArray, 0);
-    jbyte *bgr = (jbyte*) (*env)->GetPrimitiveArrayCritical(env, bgrArray, 0);
+    jbyte *rgba = (jbyte*) (*env)->GetPrimitiveArrayCritical(env, rgbaArray, 0);
+    jbyte *data_y = (jbyte*) (*env)->GetPrimitiveArrayCritical(env, dataYArray, 0);
+    jbyte *data_u = (jbyte*) (*env)->GetPrimitiveArrayCritical(env, dataUArray, 0);
+    jbyte *data_v = (jbyte*) (*env)->GetPrimitiveArrayCritical(env, dataVArray, 0);
 
-    ABGRToARGB((uint8*) rgb, width << 2, (uint8*) bgr, width << 2, width, height);
+    // ABGR little endian (rgba in memory) to I420.
+    /*
+    LIBYUV_API
+    int ABGRToI420(const uint8* src_frame, int src_stride_frame,
+                   uint8* dst_y, int dst_stride_y,
+                   uint8* dst_u, int dst_stride_u,
+                   uint8* dst_v, int dst_stride_v,
+                   int width, int height);
 
-    (*env)->ReleasePrimitiveArrayCritical(env, bgrArray, bgr, 0);
-    (*env)->ReleasePrimitiveArrayCritical(env, rgbArray, rgb, 0);
-}
+    LIBYUV_API
+    int ARGBToI420(const uint8* src_argb, int src_stride_argb,
+                   uint8* dst_y, int dst_stride_y,
+                   uint8* dst_u, int dst_stride_u,
+                   uint8* dst_v, int dst_stride_v,
+                   int width, int height);
+    */
 
-// most of this code is borrowed from
-// https://github.com/alzybaad/RGB2YUV/
-JNIEXPORT void JNICALL
-Java_jp_shiguredo_webrtc_video_effector_format_LibYuvBridge_bgrToYuvInternal(
-        JNIEnv *env,
-        jobject obj,
-        jbyteArray bgrArray,
-        jint width,
-        jint height,
-        jbyteArray yuvArray)
-{
-    jbyte *bgr = (jbyte*)(*env)->GetPrimitiveArrayCritical(env, bgrArray, 0);
-    jbyte *yuv = (jbyte*)(*env)->GetPrimitiveArrayCritical(env, yuvArray, 0);
-    ARGBToNV21((uint8*) bgr, width << 2, (uint8*) yuv, width, (uint8*) &yuv[width * height], width, width, height);
-    (*env)->ReleasePrimitiveArrayCritical(env, yuvArray, yuv, 0);
-    (*env)->ReleasePrimitiveArrayCritical(env, bgrArray, bgr, 0);
+    ABGRToI420((uint8*) rgba, width * 4,
+               (uint8*) data_y, strideY,
+               (uint8*) data_u, strideU,
+               (uint8*) data_v, strideV,
+               width, height);
+
+    (*env)->ReleasePrimitiveArrayCritical(env, rgbaArray, rgba, 0);
+    (*env)->ReleasePrimitiveArrayCritical(env, dataYArray, data_y, 0);
+    (*env)->ReleasePrimitiveArrayCritical(env, dataUArray, data_u, 0);
+    (*env)->ReleasePrimitiveArrayCritical(env, dataVArray, data_v, 0);
 }

--- a/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/CapturerObserverProxy.java
+++ b/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/CapturerObserverProxy.java
@@ -58,19 +58,14 @@ public class CapturerObserverProxy implements CapturerObserver {
 
             final int width = i420Buffer.getWidth();
             final int height = i420Buffer.getHeight();
-            final int strideY = i420Buffer.getStrideY();
 
-
-            ByteBuffer effectedByteBuffer =
+            VideoFrame.I420Buffer effectedI420Buffer =
                     this.videoEffector.processByteBufferFrame(i420Buffer, width, height,
                             frame.getRotation(), frame.getTimestampNs());
 
-            VideoFrame.Buffer filteredBuffer = new NV12Buffer(width, height, strideY, height,
-                    effectedByteBuffer, null);
-            VideoFrame filteredVideoFrame = new VideoFrame(
-                    filteredBuffer, frame.getRotation(), frame.getTimestampNs());
-            filteredBuffer.release();
-            this.originalObserver.onFrameCaptured(filteredVideoFrame);
+            VideoFrame effectedVideoFrame = new VideoFrame(
+                    effectedI420Buffer, frame.getRotation(), frame.getTimestampNs());
+            this.originalObserver.onFrameCaptured(effectedVideoFrame);
         } else {
             this.originalObserver.onFrameCaptured(frame);
         }

--- a/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/CapturerObserverProxy.java
+++ b/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/CapturerObserverProxy.java
@@ -59,24 +59,10 @@ public class CapturerObserverProxy implements CapturerObserver {
             final int width = i420Buffer.getWidth();
             final int height = i420Buffer.getHeight();
             final int strideY = i420Buffer.getStrideY();
-            final int strideU = i420Buffer.getStrideU();
-            final int strideV = i420Buffer.getStrideV();
 
-            final int chromaWidth = (width + 1) / 2;
-            final int chromaHeight = (height + 1) / 2;
-            final int dstSize = width * height + chromaWidth * chromaHeight * 2;
-            ByteBuffer dst = ByteBuffer.allocateDirect(dstSize);
-            // TODO: libyuv には I420ToARGB があるので NV12 に変換する必要はないかもしれない。
-            //       そもそも i420Buffer の byte[] が一直線の保証はないし、
-            //       下回りの byte[] を取得する方法も無い
-            YuvHelper.I420ToNV12(i420Buffer.getDataY(), strideY,
-                    i420Buffer.getDataU(), strideU,
-                    i420Buffer.getDataV(), strideV,
-                    dst, width, height);
-            i420Buffer.release();
 
             ByteBuffer effectedByteBuffer =
-                    this.videoEffector.processByteBufferFrame(dst, width, height,
+                    this.videoEffector.processByteBufferFrame(i420Buffer, width, height,
                             frame.getRotation(), frame.getTimestampNs());
 
             VideoFrame.Buffer filteredBuffer = new NV12Buffer(width, height, strideY, height,

--- a/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/CapturerObserverProxy.java
+++ b/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/CapturerObserverProxy.java
@@ -54,7 +54,6 @@ public class CapturerObserverProxy implements CapturerObserver {
             // それらが一直線かどうかは不明。実装次第だが toI420 でメモリコピーは不要。
             // VideoEffectorLogger.d(TAG, "frame.getBuffer() = " + frame.getBuffer());
             // VideoEffectorLogger.d(TAG, "i420Buffer = " + i420Buffer);
-            frame.release();
 
             final int width = i420Buffer.getWidth();
             final int height = i420Buffer.getHeight();
@@ -65,6 +64,8 @@ public class CapturerObserverProxy implements CapturerObserver {
 
             VideoFrame effectedVideoFrame = new VideoFrame(
                     effectedI420Buffer, frame.getRotation(), frame.getTimestampNs());
+            frame.release();
+
             this.originalObserver.onFrameCaptured(effectedVideoFrame);
         } else {
             this.originalObserver.onFrameCaptured(frame);

--- a/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/CapturerObserverProxy.java
+++ b/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/CapturerObserverProxy.java
@@ -44,12 +44,14 @@ public class CapturerObserverProxy implements CapturerObserver {
     @Override
     public void onFrameCaptured(VideoFrame frame) {
         if (this.videoEffector.needToProcessFrame()) {
+            VideoFrame.I420Buffer originalI420Buffer = frame.getBuffer().toI420();
             VideoFrame.I420Buffer effectedI420Buffer =
                     this.videoEffector.processByteBufferFrame(
-                            frame.getBuffer().toI420(), frame.getRotation(), frame.getTimestampNs());
+                            originalI420Buffer, frame.getRotation(), frame.getTimestampNs());
 
             VideoFrame effectedVideoFrame = new VideoFrame(
                     effectedI420Buffer, frame.getRotation(), frame.getTimestampNs());
+            originalI420Buffer.release();
             frame.release();
 
             this.originalObserver.onFrameCaptured(effectedVideoFrame);

--- a/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/CapturerObserverProxy.java
+++ b/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/CapturerObserverProxy.java
@@ -44,23 +44,9 @@ public class CapturerObserverProxy implements CapturerObserver {
     @Override
     public void onFrameCaptured(VideoFrame frame) {
         if (this.videoEffector.needToProcessFrame()) {
-            // TODO(shino): libwebrtc 66.8.1, Android 7.0/Xperia Z4 では frame.getBuffer() は
-            // org.webrtc.NV21Buffer で実装されている。
-            // NV21Buffer には private data :: byte[] があるがアクセスは出来ない。
-            // VideoEffectorLogger.d(TAG, "frame.getBuffer: " + frame.getBuffer());
-
-            final VideoFrame.I420Buffer i420Buffer = frame.getBuffer().toI420();
-            // TODO: JavaI420Buffer は direct ByteBuffer を3つ別に持っている。
-            // それらが一直線かどうかは不明。実装次第だが toI420 でメモリコピーは不要。
-            // VideoEffectorLogger.d(TAG, "frame.getBuffer() = " + frame.getBuffer());
-            // VideoEffectorLogger.d(TAG, "i420Buffer = " + i420Buffer);
-
-            final int width = i420Buffer.getWidth();
-            final int height = i420Buffer.getHeight();
-
             VideoFrame.I420Buffer effectedI420Buffer =
-                    this.videoEffector.processByteBufferFrame(i420Buffer, width, height,
-                            frame.getRotation(), frame.getTimestampNs());
+                    this.videoEffector.processByteBufferFrame(
+                            frame.getBuffer().toI420(), frame.getRotation(), frame.getTimestampNs());
 
             VideoFrame effectedVideoFrame = new VideoFrame(
                     effectedI420Buffer, frame.getRotation(), frame.getTimestampNs());

--- a/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/RTCVideoEffector.java
+++ b/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/RTCVideoEffector.java
@@ -95,6 +95,14 @@ public class RTCVideoEffector {
             return i420Buffer;
         }
 
+        // Direct buffer ではない場合スルーする
+        // TODO: direct に変換してあげる手もある
+        if(!i420Buffer.getDataY().isDirect()
+                || !i420Buffer.getDataU().isDirect()
+                || !i420Buffer.getDataV().isDirect()) {
+            return i420Buffer;
+        }
+
         int strideY = i420Buffer.getStrideY();
         int strideU = i420Buffer.getStrideU();
         int strideV = i420Buffer.getStrideV();

--- a/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/RTCVideoEffector.java
+++ b/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/RTCVideoEffector.java
@@ -58,6 +58,7 @@ public class RTCVideoEffector {
     public void addMediaEffectFilter(String name) {
         addMediaEffectFilter(name, null);
     }
+
     public void addMediaEffectFilter(String name,
                                      MediaEffectFilter.Listener listener) {
         VideoEffectorLogger.d(TAG, "addMediaEffectFilter: " + name +
@@ -69,6 +70,7 @@ public class RTCVideoEffector {
         VideoEffectorLogger.d(TAG, "addGPUImageFilter: " + filter.toString());
         this.filters.add(new GPUImageFilterWrapper(filter));
     }
+
     public void addGPUImageFilter(GPUImageFilter filter,
                                   GPUImageFilterWrapper.Listener listener) {
         VideoEffectorLogger.d(TAG, "addGPUImageFilter: " + filter.toString() +
@@ -88,7 +90,7 @@ public class RTCVideoEffector {
         enabled = false;
     }
 
-    VideoFrame.I420Buffer processByteBufferFrame(VideoFrame.I420Buffer i420Buffer, int width, int height,
+    VideoFrame.I420Buffer processByteBufferFrame(VideoFrame.I420Buffer i420Buffer,
                                                  int rotation, long timestamp) {
 
         if (!needToProcessFrame()) {
@@ -103,13 +105,15 @@ public class RTCVideoEffector {
             return i420Buffer;
         }
 
+        int width = i420Buffer.getWidth();
+        int height = i420Buffer.getHeight();
         int strideY = i420Buffer.getStrideY();
         int strideU = i420Buffer.getStrideU();
         int strideV = i420Buffer.getStrideV();
 
         context.updateFrameInfo(width, height, rotation, timestamp);
 
-        int stepTextureId = yuvBytesReader.read(i420Buffer, width, height);
+        int stepTextureId = yuvBytesReader.read(i420Buffer);
 
         // ビデオフレームの画像は回転された状態で来ることがある
         // グレースケールやセピアフィルタなど、画像全体に均質にかけるエフェクトでは問題にならないが

--- a/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/RTCVideoEffector.java
+++ b/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/RTCVideoEffector.java
@@ -3,6 +3,7 @@ package jp.shiguredo.webrtc.video.effector;
 import org.webrtc.GlUtil;
 import org.webrtc.SurfaceTextureHelper;
 import org.webrtc.ThreadUtils;
+import org.webrtc.VideoFrame;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -87,18 +88,18 @@ public class RTCVideoEffector {
         enabled = false;
     }
 
-    ByteBuffer processByteBufferFrame(ByteBuffer byteBuffer, int width, int height,
-                                  int rotation, long timestamp) {
+    VideoFrame.I420Buffer processByteBufferFrame(VideoFrame.I420Buffer i420Buffer, int width, int height,
+                                                 int rotation, long timestamp) {
 
         if (!needToProcessFrame()) {
-            return byteBuffer;
+            return i420Buffer;
         }
 
-        byte[] bytes = byteBuffer.array();
+        // byte[] bytes = byteBuffer.array();
 
-        context.updateFrameInfo(bytes, width, height, rotation, timestamp);
+        context.updateFrameInfo(width, height, rotation, timestamp);
 
-        int stepTextureId = yuvBytesReader.read(bytes, width, height);
+        int stepTextureId = yuvBytesReader.read(i420Buffer, width, height);
 
         // ビデオフレームの画像は回転された状態で来ることがある
         // グレースケールやセピアフィルタなど、画像全体に均質にかけるエフェクトでは問題にならないが

--- a/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/RTCVideoEffector.java
+++ b/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/RTCVideoEffector.java
@@ -95,7 +95,9 @@ public class RTCVideoEffector {
             return i420Buffer;
         }
 
-        // byte[] bytes = byteBuffer.array();
+        int strideY = i420Buffer.getStrideY();
+        int strideU = i420Buffer.getStrideU();
+        int strideV = i420Buffer.getStrideV();
 
         context.updateFrameInfo(width, height, rotation, timestamp);
 
@@ -123,7 +125,7 @@ public class RTCVideoEffector {
             // TODO
         }
 
-        return yuvBytesDumper.dump(stepTextureId, width, height);
+        return yuvBytesDumper.dump(stepTextureId, width, height, strideY, strideU, strideV);
     }
 
     boolean needToProcessFrame() {

--- a/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/VideoEffectorContext.java
+++ b/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/VideoEffectorContext.java
@@ -16,14 +16,12 @@ public class VideoEffectorContext {
         private int rotation = 0;
         private long timestamp = 0;
         private boolean rotated = false;
-        private byte[] bytes = null;
 
         private boolean transformChanged = true;
 
         public FrameInfo() {}
 
-        public void update(byte[] bytes,
-                           int width,
+        public void update(int width,
                            int height,
                            int rotation,
                            long timestamp) {
@@ -36,7 +34,6 @@ public class VideoEffectorContext {
                 this.transformChanged = false;
             }
 
-            this.bytes = bytes;
             this.originalWidth = width;
             this.originalHeight = height;
             this.rotation  = rotation;
@@ -69,10 +66,6 @@ public class VideoEffectorContext {
             return this.originalHeight;
         }
 
-        public byte[] getBytes() {
-            return this.bytes;
-        }
-
         public int getWidth() {
             // TODO fix to width
             return this.originalWidth;
@@ -92,7 +85,6 @@ public class VideoEffectorContext {
         }
     }
 
-    private Map<String, PointF> stash = new HashMap<>();
     private FrameInfo frameInfo = new FrameInfo();
 
     public VideoEffectorContext() {}
@@ -109,28 +101,12 @@ public class VideoEffectorContext {
         }
     }
 
-    void updateFrameInfo(byte[] bytes,
-                         int width,
+    void updateFrameInfo(int width,
                          int height,
                          int rotation,
                          long timestamp) {
-        this.frameInfo.update(bytes, width, height, rotation, timestamp);
+        this.frameInfo.update(width, height, rotation, timestamp);
     }
 
-    public void setStash(String key, PointF point) {
-        this.stash.put(key, point);
-    }
-
-    public PointF getStash(String key) {
-        if (this.stash.containsKey(key)) {
-            return this.stash.get(key);
-        } else {
-            return null;
-        }
-    }
-
-    public void clearStash() {
-        this.stash.clear();
-    }
 }
 

--- a/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/LibYuvBridge.java
+++ b/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/LibYuvBridge.java
@@ -35,13 +35,15 @@ public class LibYuvBridge {
 
     public void rgbaToI420(ByteBuffer rgbaBuffer,
                            int width, int height,
-                           ByteBuffer dataYBuffer, int strideY,
-                           ByteBuffer dataUBuffer, int strideU,
-                           ByteBuffer dataVBuffer, int strideV) {
+                           ByteBuffer outDataYBuffer, int strideY,
+                           ByteBuffer outDataUBuffer, int strideU,
+                           ByteBuffer outDataVBuffer, int strideV) {
         abgrToI420Internal(
                 rgbaBuffer,
                 width, height,
-                dataYBuffer, strideY, dataUBuffer, strideU, dataVBuffer, strideV);
+                outDataYBuffer, strideY,
+                outDataUBuffer, strideU,
+                outDataVBuffer, strideV);
     }
 
     private native void i420ToAbgrInternal(

--- a/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/LibYuvBridge.java
+++ b/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/LibYuvBridge.java
@@ -33,15 +33,15 @@ public class LibYuvBridge {
                 outRgbaBuffer);
     }
 
-    public void rgbaToI420(byte[] rgba,
+    public void rgbaToI420(ByteBuffer rgbaBuffer,
                            int width, int height,
-                           byte[] dataY, int strideY,
-                           byte[] dataU, int strideU,
-                           byte[] dataV, int strideV) {
+                           ByteBuffer dataYBuffer, int strideY,
+                           ByteBuffer dataUBuffer, int strideU,
+                           ByteBuffer dataVBuffer, int strideV) {
         abgrToI420Internal(
-                rgba,
+                rgbaBuffer,
                 width, height,
-                dataY, strideY, dataU, strideU, dataV, strideV);
+                dataYBuffer, strideY, dataUBuffer, strideU, dataVBuffer, strideV);
     }
 
     private native void i420ToAbgrInternal(
@@ -52,9 +52,9 @@ public class LibYuvBridge {
             ByteBuffer outRgbaBuffer);
 
     private native void abgrToI420Internal(
-            byte[] rgba,
+            ByteBuffer rgbaBuffer,
             int width, int height,
-            byte[] dataY, int strideY,
-            byte[] dataU, int strideU,
-            byte[] dataV, int strideV);
+            ByteBuffer outDataYBuffer, int strideY,
+            ByteBuffer outDataUBuffer, int strideU,
+            ByteBuffer outDataVBuffer, int strideV);
 }

--- a/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/LibYuvBridge.java
+++ b/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/LibYuvBridge.java
@@ -10,26 +10,26 @@ public class LibYuvBridge {
 
     public LibYuvBridge() {}
 
-    public void i420ToRgba(VideoFrame.I420Buffer i420Buffer, int width, int height, byte[] out) {
+    // TODO: byte[] と stride 渡しに変更する
+    public void i420ToRgba(VideoFrame.I420Buffer i420Buffer, int width, int height, byte[] outRgba) {
         i420ToRgbaInternal(i420Buffer.getDataY().array(), i420Buffer.getStrideY(),
                 i420Buffer.getDataU().array(), i420Buffer.getStrideU(),
                 i420Buffer.getDataV().array(), i420Buffer.getStrideV(),
-                width, height, out);
+                width, height, outRgba);
     }
 
-    private byte[] tempBgr;
-
-    public void rgbToYuv(byte[] rgb, int width, int height, byte[] yuv) {
-        if (tempBgr == null || tempBgr.length < rgb.length) {
-            tempBgr = new byte[rgb.length];
-        }
-        rgbToBgrInternal(rgb, width, height, tempBgr);
-        bgrToYuvInternal(tempBgr, width, height, yuv);
+    public void rgbaToI420(byte[] rgba, int width, int height,
+                           byte[] dataY, int strideY,
+                           byte[] dataU, int strideU,
+                           byte[] dataV, int strideV) {
+        rgbaToI420Internal(rgba, width, height, dataY, strideY, dataU, strideU, dataV, strideV);
     }
 
     private native void i420ToRgbaInternal(byte[] dataY, int strideY, byte[] dataU, int strideU,
                                            byte[] dataV, int strideV, int width, int height,
-                                           byte[] out);
-    private native void rgbToBgrInternal(byte[] rgb, int width, int height, byte[] bgr);
-    private native void bgrToYuvInternal(byte[] bgr, int width, int height, byte[] yuv);
+                                           byte[] outRgba);
+    private native void rgbaToI420Internal(byte[] rgba, int width, int height,
+                                           byte[] dataY, int strideY,
+                                           byte[] dataU, int strideU,
+                                           byte[] dataV, int strideV);
 }

--- a/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/LibYuvBridge.java
+++ b/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/LibYuvBridge.java
@@ -11,10 +11,11 @@ public class LibYuvBridge {
     public LibYuvBridge() {}
 
     // TODO: byte[] と stride 渡しに変更する
-    public void i420ToRgba(VideoFrame.I420Buffer i420Buffer, int width, int height, byte[] outRgba) {
-        i420ToRgbaInternal(i420Buffer.getDataY().array(), i420Buffer.getStrideY(),
-                i420Buffer.getDataU().array(), i420Buffer.getStrideU(),
-                i420Buffer.getDataV().array(), i420Buffer.getStrideV(),
+    public void i420ToRgba(byte[] dataY, int strideY, byte[] dataU, int strideU,
+            byte[] dataV, int strideV, int width, int height, byte[] outRgba) {
+        i420ToRgbaInternal(dataY, strideY,
+                dataU, strideU,
+                dataV, strideV,
                 width, height, outRgba);
     }
 

--- a/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/LibYuvBridge.java
+++ b/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/LibYuvBridge.java
@@ -1,5 +1,7 @@
 package jp.shiguredo.webrtc.video.effector.format;
 
+import org.webrtc.VideoFrame;
+
 public class LibYuvBridge {
 
     static {
@@ -8,8 +10,11 @@ public class LibYuvBridge {
 
     public LibYuvBridge() {}
 
-    public void yuvToRgba(byte[] yuv, int width, int height, byte[] out) {
-        yuvToRgbaInternal(yuv, width, height, out);
+    public void i420ToRgba(VideoFrame.I420Buffer i420Buffer, int width, int height, byte[] out) {
+        i420ToRgbaInternal(i420Buffer.getDataY().array(), i420Buffer.getStrideY(),
+                i420Buffer.getDataU().array(), i420Buffer.getStrideU(),
+                i420Buffer.getDataV().array(), i420Buffer.getStrideV(),
+                width, height, out);
     }
 
     private byte[] tempBgr;
@@ -22,7 +27,9 @@ public class LibYuvBridge {
         bgrToYuvInternal(tempBgr, width, height, yuv);
     }
 
-    private native void yuvToRgbaInternal(byte[] yuv, int width, int height, byte[] out);
+    private native void i420ToRgbaInternal(byte[] dataY, int strideY, byte[] dataU, int strideU,
+                                           byte[] dataV, int strideV, int width, int height,
+                                           byte[] out);
     private native void rgbToBgrInternal(byte[] rgb, int width, int height, byte[] bgr);
     private native void bgrToYuvInternal(byte[] bgr, int width, int height, byte[] yuv);
 }

--- a/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/LibYuvBridge.java
+++ b/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/LibYuvBridge.java
@@ -24,13 +24,13 @@ public class LibYuvBridge {
                            ByteBuffer dataUBuffer, int strideU,
                            ByteBuffer dataVBuffer, int strideV,
                            int width, int height,
-                           byte[] outRgba) {
+                           ByteBuffer outRgbaBuffer) {
         i420ToAbgrInternal(
                 dataYBuffer, strideY,
                 dataUBuffer, strideU,
                 dataVBuffer, strideV,
                 width, height,
-                outRgba);
+                outRgbaBuffer);
     }
 
     public void rgbaToI420(byte[] rgba,
@@ -49,7 +49,7 @@ public class LibYuvBridge {
             ByteBuffer dataUBuffer, int strideU,
             ByteBuffer dataVBuffer, int strideV,
             int width, int height,
-            byte[] outRgba);
+            ByteBuffer outRgbaBuffer);
 
     private native void abgrToI420Internal(
             byte[] rgba,

--- a/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/LibYuvBridge.java
+++ b/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/LibYuvBridge.java
@@ -2,6 +2,8 @@ package jp.shiguredo.webrtc.video.effector.format;
 
 import org.webrtc.VideoFrame;
 
+import java.nio.ByteBuffer;
+
 /** I420 と RGBA の間の変換を受け持つクラス。
  *
  * メモリイメージとして RGBA にしたい。libyuv の RGBA 変換はメモリ上のバイト順が
@@ -18,15 +20,15 @@ public class LibYuvBridge {
 
     public LibYuvBridge() {}
 
-    public void i420ToRgba(byte[] dataY, int strideY,
-                           byte[] dataU, int strideU,
-                           byte[] dataV, int strideV,
+    public void i420ToRgba(ByteBuffer dataYBuffer, int strideY,
+                           ByteBuffer dataUBuffer, int strideU,
+                           ByteBuffer dataVBuffer, int strideV,
                            int width, int height,
                            byte[] outRgba) {
         i420ToAbgrInternal(
-                dataY, strideY,
-                dataU, strideU,
-                dataV, strideV,
+                dataYBuffer, strideY,
+                dataUBuffer, strideU,
+                dataVBuffer, strideV,
                 width, height,
                 outRgba);
     }
@@ -43,9 +45,9 @@ public class LibYuvBridge {
     }
 
     private native void i420ToAbgrInternal(
-            byte[] dataY, int strideY,
-            byte[] dataU, int strideU,
-            byte[] dataV, int strideV,
+            ByteBuffer dataYBuffer, int strideY,
+            ByteBuffer dataUBuffer, int strideU,
+            ByteBuffer dataVBuffer, int strideV,
             int width, int height,
             byte[] outRgba);
 

--- a/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/LibYuvBridge.java
+++ b/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/LibYuvBridge.java
@@ -8,7 +8,7 @@ public class LibYuvBridge {
 
     public LibYuvBridge() {}
 
-    public void yuvToRgba(byte[] yuv, int width, int height, int[] out) {
+    public void yuvToRgba(byte[] yuv, int width, int height, byte[] out) {
         yuvToRgbaInternal(yuv, width, height, out);
     }
 
@@ -22,7 +22,7 @@ public class LibYuvBridge {
         bgrToYuvInternal(tempBgr, width, height, yuv);
     }
 
-    private native void yuvToRgbaInternal(byte[] yuv, int width, int height, int[] out);
+    private native void yuvToRgbaInternal(byte[] yuv, int width, int height, byte[] out);
     private native void rgbToBgrInternal(byte[] rgb, int width, int height, byte[] bgr);
     private native void bgrToYuvInternal(byte[] bgr, int width, int height, byte[] yuv);
 }

--- a/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/LibYuvBridge.java
+++ b/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/LibYuvBridge.java
@@ -2,6 +2,14 @@ package jp.shiguredo.webrtc.video.effector.format;
 
 import org.webrtc.VideoFrame;
 
+/** I420 と RGBA の間の変換を受け持つクラス。
+ *
+ * メモリイメージとして RGBA にしたい。libyuv の RGBA 変換はメモリ上のバイト順が
+ * 逆順になる。
+ * I420ToARGB() の出力はバイト順として B G R A、I420ToABGR() は R G B A  である。
+ * 関数の命名として、Java の世界はメモリ順で命名し、native method では libyuv に
+ * 合わせて逆順とする。
+ */
 public class LibYuvBridge {
 
     static {
@@ -10,27 +18,41 @@ public class LibYuvBridge {
 
     public LibYuvBridge() {}
 
-    public void i420ToRgba(byte[] dataY, int strideY, byte[] dataU, int strideU,
-            byte[] dataV, int strideV, int width, int height, byte[] outRgba) {
-        i420ToRgbaInternal(dataY, strideY,
+    public void i420ToRgba(byte[] dataY, int strideY,
+                           byte[] dataU, int strideU,
+                           byte[] dataV, int strideV,
+                           int width, int height,
+                           byte[] outRgba) {
+        i420ToAbgrInternal(
+                dataY, strideY,
                 dataU, strideU,
                 dataV, strideV,
-                width, height, outRgba);
+                width, height,
+                outRgba);
     }
 
-    public void rgbaToI420(byte[] rgba, int width, int height,
+    public void rgbaToI420(byte[] rgba,
+                           int width, int height,
                            byte[] dataY, int strideY,
                            byte[] dataU, int strideU,
                            byte[] dataV, int strideV) {
-        rgbaToI420Internal(rgba, width, height, dataY, strideY, dataU, strideU, dataV, strideV);
+        abgrToI420Internal(
+                rgba,
+                width, height,
+                dataY, strideY, dataU, strideU, dataV, strideV);
     }
 
-    private native void i420ToRgbaInternal(byte[] dataY, int strideY, byte[] dataU, int strideU,
-                                           byte[] dataV, int strideV, int width, int height,
-                                           byte[] outRgba);
+    private native void i420ToAbgrInternal(
+            byte[] dataY, int strideY,
+            byte[] dataU, int strideU,
+            byte[] dataV, int strideV,
+            int width, int height,
+            byte[] outRgba);
 
-    private native void rgbaToI420Internal(byte[] rgba, int width, int height,
-                                           byte[] dataY, int strideY,
-                                           byte[] dataU, int strideU,
-                                           byte[] dataV, int strideV);
+    private native void abgrToI420Internal(
+            byte[] rgba,
+            int width, int height,
+            byte[] dataY, int strideY,
+            byte[] dataU, int strideU,
+            byte[] dataV, int strideV);
 }

--- a/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/LibYuvBridge.java
+++ b/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/LibYuvBridge.java
@@ -10,7 +10,6 @@ public class LibYuvBridge {
 
     public LibYuvBridge() {}
 
-    // TODO: byte[] と stride 渡しに変更する
     public void i420ToRgba(byte[] dataY, int strideY, byte[] dataU, int strideU,
             byte[] dataV, int strideV, int width, int height, byte[] outRgba) {
         i420ToRgbaInternal(dataY, strideY,
@@ -29,6 +28,7 @@ public class LibYuvBridge {
     private native void i420ToRgbaInternal(byte[] dataY, int strideY, byte[] dataU, int strideU,
                                            byte[] dataV, int strideV, int width, int height,
                                            byte[] outRgba);
+
     private native void rgbaToI420Internal(byte[] rgba, int width, int height,
                                            byte[] dataY, int strideY,
                                            byte[] dataU, int strideU,

--- a/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/YuvByteBufferDumper.java
+++ b/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/YuvByteBufferDumper.java
@@ -33,22 +33,31 @@ public class YuvByteBufferDumper {
         GLES20.glFramebufferTexture2D(GLES20.GL_FRAMEBUFFER, GLES20.GL_COLOR_ATTACHMENT0,
                                 GLES20.GL_TEXTURE_2D, lastTextureId, 0);
 
-        final ByteBuffer buf = ByteBuffer.allocateDirect(width * height * 4);
+        final ByteBuffer rgba = ByteBuffer.allocateDirect(width * height * 4);
         GLES20.glViewport(0, 0, width, height);
-        GLES20.glReadPixels(0, 0, width, height, GLES20.GL_RGBA, GLES20.GL_UNSIGNED_BYTE, buf);
+        GLES20.glReadPixels(0, 0, width, height, GLES20.GL_RGBA, GLES20.GL_UNSIGNED_BYTE, rgba);
 
         GLES20.glBindFramebuffer(GLES20.GL_FRAMEBUFFER, 0);
 
-        buf.rewind();
+        rgba.rewind();
 
-        ByteBuffer dataY = ByteBuffer.allocate(strideY * height);
-        ByteBuffer dataU = ByteBuffer.allocate(strideU * height);
-        ByteBuffer dataV = ByteBuffer.allocate(strideV * height);
+        byte[] dataYArray = new byte[strideY * height];
+        byte[] dataUArray = new byte[strideU * height];
+        byte[] dataVArray = new byte[strideV * height];
 
+        libYuv.rgbaToI420(rgba.array(), width, height, dataYArray, strideY, dataUArray,
+                strideU, dataVArray, strideV);
 
-        libYuv.rgbaToI420(buf.array(), width, height, dataY.array(), strideY, dataU.array(),
-                strideU, dataV.array(), strideV);
-
+        // TODO: このコピーは避けられないか
+        ByteBuffer dataY = ByteBuffer.allocateDirect(dataYArray.length);
+        dataY.put(dataYArray);
+        dataY.rewind();
+        ByteBuffer dataU = ByteBuffer.allocateDirect(dataUArray.length);
+        dataY.put(dataYArray);
+        dataY.rewind();
+        ByteBuffer dataV = ByteBuffer.allocateDirect(dataVArray.length);
+        dataY.put(dataYArray);
+        dataY.rewind();
         return JavaI420Buffer.wrap(width, height, dataY, strideY,
                 dataU, strideU, dataV, strideV,
                 null);

--- a/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/YuvByteBufferDumper.java
+++ b/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/YuvByteBufferDumper.java
@@ -45,19 +45,21 @@ public class YuvByteBufferDumper {
         byte[] dataUArray = new byte[strideU * height];
         byte[] dataVArray = new byte[strideV * height];
 
-        libYuv.rgbaToI420(rgba.array(), width, height, dataYArray, strideY, dataUArray,
-                strideU, dataVArray, strideV);
+        libYuv.rgbaToI420(rgba.array(), width, height,
+                dataYArray, strideY,
+                dataUArray, strideU,
+                dataVArray, strideV);
 
-        // TODO: このコピーは避けられないか
+        // TODO: このコピーは避けたい、あとまわし
         ByteBuffer dataY = ByteBuffer.allocateDirect(dataYArray.length);
         dataY.put(dataYArray);
         dataY.rewind();
         ByteBuffer dataU = ByteBuffer.allocateDirect(dataUArray.length);
-        dataY.put(dataYArray);
-        dataY.rewind();
+        dataU.put(dataUArray);
+        dataU.rewind();
         ByteBuffer dataV = ByteBuffer.allocateDirect(dataVArray.length);
-        dataY.put(dataYArray);
-        dataY.rewind();
+        dataV.put(dataVArray);
+        dataV.rewind();
         return JavaI420Buffer.wrap(width, height, dataY, strideY,
                 dataU, strideU, dataV, strideV,
                 null);

--- a/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/YuvByteBufferDumper.java
+++ b/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/YuvByteBufferDumper.java
@@ -45,7 +45,9 @@ public class YuvByteBufferDumper {
         byte[] dataUArray = new byte[strideU * height];
         byte[] dataVArray = new byte[strideV * height];
 
-        libYuv.rgbaToI420(rgba.array(), width, height,
+        libYuv.rgbaToI420(
+                rgba.array(),
+                width, height,
                 dataYArray, strideY,
                 dataUArray, strideU,
                 dataVArray, strideV);
@@ -60,8 +62,9 @@ public class YuvByteBufferDumper {
         ByteBuffer dataV = ByteBuffer.allocateDirect(dataVArray.length);
         dataV.put(dataVArray);
         dataV.rewind();
-        return JavaI420Buffer.wrap(width, height, dataY, strideY,
-                dataU, strideU, dataV, strideV,
+        return JavaI420Buffer.wrap(
+                width, height,
+                dataY, strideY, dataU, strideU, dataV, strideV,
                 null);
     }
 

--- a/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/YuvByteBufferDumper.java
+++ b/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/YuvByteBufferDumper.java
@@ -9,8 +9,6 @@ import org.webrtc.VideoFrame;
 
 import java.nio.ByteBuffer;
 
-import jp.shiguredo.webrtc.video.effector.VideoEffectorLogger;
-
 public class YuvByteBufferDumper {
 
     public static final String TAG = YuvByteBufferDumper.class.getSimpleName();

--- a/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/YuvByteBufferReader.java
+++ b/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/YuvByteBufferReader.java
@@ -3,12 +3,11 @@ package jp.shiguredo.webrtc.video.effector.format;
 import android.opengl.GLES20;
 
 import org.webrtc.GlUtil;
+import org.webrtc.VideoFrame;
 
 import java.nio.ByteBuffer;
 
 import jp.shiguredo.webrtc.video.effector.VideoEffectorLogger;
-
-// Read RGB texture from YUV formatted bytes
 
 public class YuvByteBufferReader {
 
@@ -55,11 +54,11 @@ public class YuvByteBufferReader {
         GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, 0);
     }
 
-    public int read(byte[] data, int width, int height) {
+    public int read(VideoFrame.I420Buffer i420Buffer, int width, int height) {
         resizeTextureIfNeeded(width, height);
 
         ByteBuffer buf = ByteBuffer.allocate(width * height * 4);
-        libYuv.yuvToRgba(data, width, height, buf.array());
+        libYuv.i420ToRgba(i420Buffer, width, height, buf.array());
 
         GLES20.glActiveTexture(GLES20.GL_TEXTURE0);
         GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, textureId);

--- a/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/YuvByteBufferReader.java
+++ b/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/YuvByteBufferReader.java
@@ -57,27 +57,19 @@ public class YuvByteBufferReader {
     public int read(VideoFrame.I420Buffer i420Buffer, int width, int height) {
         resizeTextureIfNeeded(width, height);
 
-        // TODO: direct buffer だと配列が取れない、コピー以外の方法はある?
-        byte[] dataY = new byte[i420Buffer.getDataY().capacity()];
-        i420Buffer.getDataY().get(dataY);
-        byte[] dataU = new byte[i420Buffer.getDataU().capacity()];
-        i420Buffer.getDataU().get(dataU);
-        byte[] dataV = new byte[i420Buffer.getDataV().capacity()];
-        i420Buffer.getDataV().get(dataV);
-
-        ByteBuffer outRgba = ByteBuffer.allocate(width * height * 4);
-
+        ByteBuffer outRgbaBuffer = ByteBuffer.allocate(width * height * 4);
         libYuv.i420ToRgba(
-                dataY, i420Buffer.getStrideY(),
-                dataU, i420Buffer.getStrideU(),
-                dataV, i420Buffer.getStrideV(),
+                i420Buffer.getDataY(), i420Buffer.getStrideY(),
+                i420Buffer.getDataU(), i420Buffer.getStrideU(),
+                i420Buffer.getDataV(), i420Buffer.getStrideV(),
                 width, height,
-                outRgba.array());
+                outRgbaBuffer.array());
 
         GLES20.glActiveTexture(GLES20.GL_TEXTURE0);
         GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, textureId);
         GLES20.glTexSubImage2D(GLES20.GL_TEXTURE_2D, 0, 0, 0, width, height,
-                                GLES20.GL_RGBA, GLES20.GL_UNSIGNED_BYTE, outRgba);
+                GLES20.GL_RGBA, GLES20.GL_UNSIGNED_BYTE,
+                outRgbaBuffer);
         GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, 0);
 
         return textureId;

--- a/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/YuvByteBufferReader.java
+++ b/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/YuvByteBufferReader.java
@@ -4,7 +4,7 @@ import android.opengl.GLES20;
 
 import org.webrtc.GlUtil;
 
-import java.nio.IntBuffer;
+import java.nio.ByteBuffer;
 
 import jp.shiguredo.webrtc.video.effector.VideoEffectorLogger;
 
@@ -58,7 +58,7 @@ public class YuvByteBufferReader {
     public int read(byte[] data, int width, int height) {
         resizeTextureIfNeeded(width, height);
 
-        IntBuffer buf = IntBuffer.allocate(width * height);
+        ByteBuffer buf = ByteBuffer.allocate(width * height * 4);
         libYuv.yuvToRgba(data, width, height, buf.array());
 
         GLES20.glActiveTexture(GLES20.GL_TEXTURE0);

--- a/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/YuvByteBufferReader.java
+++ b/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/YuvByteBufferReader.java
@@ -67,8 +67,10 @@ public class YuvByteBufferReader {
 
         ByteBuffer outRgba = ByteBuffer.allocate(width * height * 4);
 
-        libYuv.i420ToRgba(dataY, i420Buffer.getStrideY(), dataU, i420Buffer.getStrideU(),
-                dataV, i420Buffer.getStrideV(), width, height, outRgba.array());
+        libYuv.i420ToRgba(dataY, i420Buffer.getStrideY(),
+                dataU, i420Buffer.getStrideU(),
+                dataV, i420Buffer.getStrideV(),
+                width, height, outRgba.array());
 
         GLES20.glActiveTexture(GLES20.GL_TEXTURE0);
         GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, textureId);

--- a/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/YuvByteBufferReader.java
+++ b/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/YuvByteBufferReader.java
@@ -67,10 +67,12 @@ public class YuvByteBufferReader {
 
         ByteBuffer outRgba = ByteBuffer.allocate(width * height * 4);
 
-        libYuv.i420ToRgba(dataY, i420Buffer.getStrideY(),
+        libYuv.i420ToRgba(
+                dataY, i420Buffer.getStrideY(),
                 dataU, i420Buffer.getStrideU(),
                 dataV, i420Buffer.getStrideV(),
-                width, height, outRgba.array());
+                width, height,
+                outRgba.array());
 
         GLES20.glActiveTexture(GLES20.GL_TEXTURE0);
         GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, textureId);

--- a/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/YuvByteBufferReader.java
+++ b/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/YuvByteBufferReader.java
@@ -7,8 +7,6 @@ import org.webrtc.VideoFrame;
 
 import java.nio.ByteBuffer;
 
-import jp.shiguredo.webrtc.video.effector.VideoEffectorLogger;
-
 public class YuvByteBufferReader {
 
     public static final String TAG = YuvByteBufferReader.class.getSimpleName();
@@ -54,7 +52,10 @@ public class YuvByteBufferReader {
         GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, 0);
     }
 
-    public int read(VideoFrame.I420Buffer i420Buffer, int width, int height) {
+    public int read(VideoFrame.I420Buffer i420Buffer) {
+        int width = i420Buffer.getWidth();
+        int height = i420Buffer.getHeight();
+
         resizeTextureIfNeeded(width, height);
 
         ByteBuffer outRgbaBuffer = ByteBuffer.allocateDirect(width * height * 4);

--- a/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/YuvByteBufferReader.java
+++ b/webrtc-video-effector/src/main/java/jp/shiguredo/webrtc/video/effector/format/YuvByteBufferReader.java
@@ -57,13 +57,13 @@ public class YuvByteBufferReader {
     public int read(VideoFrame.I420Buffer i420Buffer, int width, int height) {
         resizeTextureIfNeeded(width, height);
 
-        ByteBuffer outRgbaBuffer = ByteBuffer.allocate(width * height * 4);
+        ByteBuffer outRgbaBuffer = ByteBuffer.allocateDirect(width * height * 4);
         libYuv.i420ToRgba(
                 i420Buffer.getDataY(), i420Buffer.getStrideY(),
                 i420Buffer.getDataU(), i420Buffer.getStrideU(),
                 i420Buffer.getDataV(), i420Buffer.getStrideV(),
                 width, height,
-                outRgbaBuffer.array());
+                outRgbaBuffer);
 
         GLES20.glActiveTexture(GLES20.GL_TEXTURE0);
         GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, textureId);


### PR DESCRIPTION
#3 で報告された、Effected video chat で I420 から変換された RGB データがずれていた問題を修正した。

- これに伴い、NV12/NV21 の経由を廃止し、I420 と RGBA の直接の相互変換とした

また、#3 の workaround で入れてもらっていたエフェクトふたつを追加した。

- セピア化のエフェクト
- デバッグ、比較用としてなにもしないエフェクト

Thanks to @daneko
