### PR TITLE
依存ライブラリのアップデート

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,13 +7,14 @@ buildscript {
     repositories {
         jcenter()
         google()
+        gradlePluginPortal()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
 
-        classpath "com.github.ben-manes:gradle-versions-plugin:0.21.0"
+        classpath "com.github.ben-manes:gradle-versions-plugin:0.38.0"
     }
 
     // アプリから参照する設定項目

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: "com.github.ben-manes.versions"
 
 buildscript {
-    ext.kotlin_version = '1.4.21'
+    ext.kotlin_version = '1.4.31'
     ext.sora_android_sdk_version = '2020.3'
 
     repositories {
@@ -10,7 +10,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.1'
+        classpath 'com.android.tools.build:gradle:4.1.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip

--- a/samples/build.gradle
+++ b/samples/build.gradle
@@ -66,13 +66,13 @@ dependencies {
     implementation "androidx.cardview:cardview:1.0.0"
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
 
-    implementation 'com.google.android.material:material:1.2.1'
+    implementation 'com.google.android.material:material:1.3.0'
     implementation 'com.jaredrummler:material-spinner:1.3.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
-    implementation 'androidx.navigation:navigation-fragment-ktx:2.3.2'
-    implementation 'androidx.navigation:navigation-ui-ktx:2.3.2'
+    implementation 'androidx.navigation:navigation-fragment-ktx:2.3.3'
+    implementation 'androidx.navigation:navigation-ui-ktx:2.3.3'
 
-    ext.pd_version = '4.7.0'
+    ext.pd_version = '4.8.0'
     implementation "org.permissionsdispatcher:permissionsdispatcher:${pd_version}"
     kapt "org.permissionsdispatcher:permissionsdispatcher-processor:${pd_version}"
 

--- a/webrtc-video-effector/build.gradle
+++ b/webrtc-video-effector/build.gradle
@@ -56,7 +56,7 @@ dependencies {
         }
     }
 
-    api 'jp.co.cyberagent.android:gpuimage:2.0.3'
+    api 'jp.co.cyberagent.android:gpuimage:2.1.0'
 }
 
 configurations.all {


### PR DESCRIPTION
## 変更内容

- 依存ライブラリーをアップデートしました
  - kotlin の `-M1` はマイルストーン・プレビューなので更新対象から外しています
- kotlin-android-extensions の警告が出ていますが、影響範囲が大きいのでこの PR では対応しません

作業後の `./gradlew dependencyUpdates` の実行結果は以下のとおりです

```
$ ./gradlew dependencyUpdates
Starting a Gradle Daemon, 2 incompatible and 2 stopped Daemons could not be reused, use --status for details

> Configure project :samples
Warning: The 'kotlin-android-extensions' Gradle plugin is deprecated. Please use this migration guide (https://goo.gle/kotlin-android-extensions-deprecation) to start working with View Binding (https://developer.android.com/topic/libraries/view-binding) and the 'kotlin-parcelize' plugin.

> Task :dependencyUpdates
dependencyUpdates.resolutionStrategy: Remove the assignment operator, '=', when setting this task property

------------------------------------------------------------
: Project Dependency Updates (report to plain text file)
------------------------------------------------------------

The following dependencies are using the latest milestone version:
 - androidx.appcompat:appcompat:1.2.0
 - androidx.cardview:cardview:1.0.0
 - androidx.constraintlayout:constraintlayout:2.0.4
 - androidx.navigation:navigation-fragment-ktx:2.3.3
 - androidx.navigation:navigation-ui-ktx:2.3.3
 - androidx.recyclerview:recyclerview:1.1.0
 - com.android.tools.build:gradle:4.1.2
 - com.github.ben-manes:gradle-versions-plugin:0.38.0
 - com.github.dcendents:android-maven-gradle-plugin:2.1
 - com.github.shiguredo:sora-android-sdk:2020.3
 - com.google.android.material:material:1.3.0
 - com.jaredrummler:material-spinner:1.3.1
 - jp.co.cyberagent.android:gpuimage:2.1.0
 - org.permissionsdispatcher:permissionsdispatcher:4.8.0
 - org.permissionsdispatcher:permissionsdispatcher-processor:4.8.0

The following dependencies have later milestone versions:
 - org.jetbrains.kotlin:kotlin-android-extensions [1.4.31 -> 1.5.0-M1]
     https://kotlinlang.org/
 - org.jetbrains.kotlin:kotlin-android-extensions-runtime [1.4.31 -> 1.5.0-M1]
     https://kotlinlang.org/
 - org.jetbrains.kotlin:kotlin-annotation-processing-gradle [1.4.31 -> 1.5.0-M1]
     https://kotlinlang.org/
 - org.jetbrains.kotlin:kotlin-gradle-plugin [1.4.31 -> 1.5.0-M1]
     https://kotlinlang.org/
 - org.jetbrains.kotlin:kotlin-reflect [1.4.31 -> 1.5.0-M1]
     https://kotlinlang.org/
 - org.jetbrains.kotlin:kotlin-stdlib-jdk7 [1.4.31 -> 1.5.0-M1]
     https://kotlinlang.org/

Gradle release-candidate updates:
 - Gradle: [6.8.3: UP-TO-DATE]

Generated report file build/dependencyUpdates/report.txt

BUILD SUCCESSFUL in 14s
1 actionable task: 1 executed
```