### PR TITLE
サイマルキャスト画面とスポットライト画面の改善

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,11 @@
 
 ## develop
 
+## ADD
+
+- サイマルキャストの接続時に simulcast_rid を指定できるようにする
+- スポットライトの接続時に spotlight_focus_rid / spotlight_unfocus_rid を指定できるようにする
+
 ### FIX
 
 - 自身の映像プレビューが反転している問題を修正する

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/facade/SoraVideoChannel.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/facade/SoraVideoChannel.kt
@@ -37,6 +37,7 @@ class SoraVideoChannel(
         private val videoWidth:                Int = SoraVideoOption.FrameSize.Portrait.VGA.x,
         private val videoHeight:               Int = SoraVideoOption.FrameSize.Portrait.VGA.y,
         private val simulcast:                 Boolean = false,
+        private val simulcastRid:              SoraVideoOption.SimulcastRid? = null,
         private val videoFPS:                  Int =  30,
         private val fixedResolution:           Boolean = false,
         private val cameraFacing:              Boolean = true,
@@ -242,7 +243,7 @@ class SoraVideoChannel(
             }
 
             if(this@SoraVideoChannel.simulcast) {
-                enableSimulcast(null)
+                enableSimulcast(simulcastRid)
             }
 
             if (this@SoraVideoChannel.spotlight) {

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/facade/SoraVideoChannel.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/facade/SoraVideoChannel.kt
@@ -31,6 +31,8 @@ class SoraVideoChannel(
         private val spotlight:                 Boolean = false,
         private val spotlightLegacy:           Boolean = false,
         private val spotlightNumber:           Int? = null,
+        private val spotlightFocusRid:         SoraVideoOption.SpotlightRid? = null,
+        private val spotlightUnfocusRid:       SoraVideoOption.SpotlightRid? = null,
         private var role:                      SoraRoleType = SoraRoleType.SENDRECV,
         private var multistream:               Boolean = true,
         private var videoEnabled:              Boolean = true,
@@ -250,6 +252,8 @@ class SoraVideoChannel(
                 val option = SoraSpotlightOption()
                 option.spotlightNumber = spotlightNumber
                 Sora.usesSpotlightLegacy = spotlightLegacy
+                option.spotlightFocusRid = spotlightFocusRid
+                option.spotlightUnfocusRid = spotlightUnfocusRid
                 enableSpotlight(option)
             }
 

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/SimulcastActivity.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/SimulcastActivity.kt
@@ -60,6 +60,7 @@ class SimulcastActivity : AppCompatActivity() {
     private var spotlightLegacy = true
     private var fps: Int = 30
     private var fixedResolution = false
+    private var simulcastRid: SoraVideoOption.SimulcastRid? = null
     private var dataChannelSignaling: Boolean? = null
     private var ignoreDisconnectWebSocket: Boolean? = null
 
@@ -174,6 +175,13 @@ class SimulcastActivity : AppCompatActivity() {
             if(resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
                 requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
             }
+        }
+
+        simulcastRid = when (intent.getStringExtra("SIMULCAST_RID")) {
+            "r0" -> SoraVideoOption.SimulcastRid.R0
+            "r1" -> SoraVideoOption.SimulcastRid.R1
+            "r2" -> SoraVideoOption.SimulcastRid.R2
+            else -> null
         }
 
         dataChannelSignaling = when (intent.getStringExtra("DATA_CHANNEL_SIGNALING")) {
@@ -302,6 +310,7 @@ class SimulcastActivity : AppCompatActivity() {
                 videoWidth                = videoWidth,
                 videoHeight               = videoHeight,
                 simulcast                 = true,
+                simulcastRid              = simulcastRid,
                 videoFPS                  = fps,
                 fixedResolution           = fixedResolution,
                 videoCodec                = videoCodec,

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/SimulcastActivity.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/SimulcastActivity.kt
@@ -58,6 +58,8 @@ class SimulcastActivity : AppCompatActivity() {
     private var spotlight = false
     private var spotlightNumber: Int? = null
     private var spotlightLegacy = true
+    private var spotlightFocusRid: SoraVideoOption.SpotlightRid? = null
+    private var spotlightUnfocusRid: SoraVideoOption.SpotlightRid? = null
     private var fps: Int = 30
     private var fixedResolution = false
     private var simulcastRid: SoraVideoOption.SimulcastRid? = null
@@ -146,6 +148,22 @@ class SimulcastActivity : AppCompatActivity() {
         spotlightLegacy = when (intent.getStringExtra("SPOTLIGHT_LEGACY")) {
             "有効" -> true
             else      -> false
+        }
+
+        spotlightFocusRid = when (intent.getStringExtra("SPOTLIGHT_FOCUS_RID")) {
+            "none" -> SoraVideoOption.SpotlightRid.NONE
+            "r0"   -> SoraVideoOption.SpotlightRid.R0
+            "r1"   -> SoraVideoOption.SpotlightRid.R1
+            "r2"   -> SoraVideoOption.SpotlightRid.R2
+            else   -> null
+        }
+
+        spotlightUnfocusRid = when (intent.getStringExtra("SPOTLIGHT_UNFOCUS_RID")) {
+            "none" -> SoraVideoOption.SpotlightRid.NONE
+            "r0"   -> SoraVideoOption.SpotlightRid.R0
+            "r1"   -> SoraVideoOption.SpotlightRid.R1
+            "r2"   -> SoraVideoOption.SpotlightRid.R2
+            else   -> null
         }
 
         fixedResolution = when (intent.getStringExtra("RESOLUTION_CHANGE")) {
@@ -306,6 +324,8 @@ class SimulcastActivity : AppCompatActivity() {
                 spotlight                 = spotlight,
                 spotlightLegacy           = spotlightLegacy,
                 spotlightNumber           = spotlightNumber,
+                spotlightFocusRid         = spotlightFocusRid,
+                spotlightUnfocusRid       = spotlightUnfocusRid,
                 videoEnabled              = videoEnabled,
                 videoWidth                = videoWidth,
                 videoHeight               = videoHeight,

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/SimulcastSetupActivity.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/SimulcastSetupActivity.kt
@@ -70,7 +70,7 @@ class SimulcastSetupActivity : AppCompatActivity() {
         fpsSelection.spinner.setItems(fpsOptions)
         resolutionChangeSelection.name.text = "解像度の変更"
         resolutionChangeSelection.spinner.setItems(resolutionChangeOptions)
-        simulcastRidSelection.name.text = "受信する RID"
+        simulcastRidSelection.name.text = "受信する rid"
         simulcastRidSelection.spinner.setItems(simulcastRidOptions)
         dataChannelSignalingSelection.name.text = "データチャネル"
         dataChannelSignalingSelection.spinner.setItems(dataChannelSignalingOptions)

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/SimulcastSetupActivity.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/SimulcastSetupActivity.kt
@@ -35,6 +35,7 @@ class SimulcastSetupActivity : AppCompatActivity() {
             "Res3840x1920", "UHD3840x2160")
     private val fpsOptions = listOf("30", "10", "15", "20", "24", "60")
     private val resolutionChangeOptions = listOf("可変", "固定")
+    private val simulcastRidOptions = listOf("未指定", "r0", "r1", "r2")
     private val dataChannelSignalingOptions = listOf("未指定", "無効", "有効")
     private val ignoreDisconnectWebSocketOptions = listOf("未指定", "無効", "有効")
 
@@ -69,6 +70,8 @@ class SimulcastSetupActivity : AppCompatActivity() {
         fpsSelection.spinner.setItems(fpsOptions)
         resolutionChangeSelection.name.text = "解像度の変更"
         resolutionChangeSelection.spinner.setItems(resolutionChangeOptions)
+        simulcastRidSelection.name.text = "受信する RID"
+        simulcastRidSelection.spinner.setItems(simulcastRidOptions)
         dataChannelSignalingSelection.name.text = "データチャネル"
         dataChannelSignalingSelection.spinner.setItems(dataChannelSignalingOptions)
         ignoreDisconnectWebSocketSelection.name.text = "WS 切断を無視"
@@ -97,6 +100,7 @@ class SimulcastSetupActivity : AppCompatActivity() {
         val videoSize = selectedItem(videoSizeSelection.spinner)
         val fps = selectedItem(fpsSelection.spinner)
         val resolutionChange = selectedItem(resolutionChangeSelection.spinner)
+        val simulcastRid = selectedItem(simulcastRidSelection.spinner)
         val dataChannelSignaling = selectedItem(dataChannelSignalingSelection.spinner)
         val ignoreDisconnectWebSocket = selectedItem(ignoreDisconnectWebSocketSelection.spinner)
 
@@ -115,6 +119,7 @@ class SimulcastSetupActivity : AppCompatActivity() {
         intent.putExtra("SIMULCAST", true)
         intent.putExtra("FPS", fps)
         intent.putExtra("RESOLUTION_CHANGE", resolutionChange)
+        intent.putExtra("SIMULCAST_RID", simulcastRid)
         intent.putExtra("DATA_CHANNEL_SIGNALING", dataChannelSignaling)
         intent.putExtra("IGNORE_DISCONNECT_WEBSOCKET", ignoreDisconnectWebSocket)
 

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/SpotlightRoomSetupActivity.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/SpotlightRoomSetupActivity.kt
@@ -26,6 +26,8 @@ class SpotlightRoomSetupActivity : AppCompatActivity() {
     private val audioEnabledOptions = listOf("有効", "無効")
     private val roleOptions = listOf("SENDRECV", "SENDONLY", "RECVONLY")
     private val legacyOptions = listOf("無効", "有効")
+    private val spotlightFocusRidOptions = listOf("未指定", "none", "r0", "r1", "r2")
+    private val spotlightUnfocusRidOptions = listOf("未指定", "none", "r0", "r1", "r2")
     private val videoBitRateOptions = listOf("500", "200", "700", "1200", "2500", "4000", "5000",
             "10000", "15000", "20000", "30000")
     private val videoSizeOptions = listOf("VGA", "QQVGA", "QCIF", "HQVGA", "QVGA", "HD", "FHD")
@@ -47,6 +49,10 @@ class SpotlightRoomSetupActivity : AppCompatActivity() {
         roleSelection.spinner.setItems(roleOptions)
         legacySelection.name.text = "レガシー機能"
         legacySelection.spinner.setItems(legacyOptions)
+        spotlightFocusRidSelection.name.text = "フォーカス時の RID"
+        spotlightFocusRidSelection.spinner.setItems(spotlightFocusRidOptions)
+        spotlightUnfocusRidSelection.name.text = "非フォーカス時の RID"
+        spotlightUnfocusRidSelection.spinner.setItems(spotlightUnfocusRidOptions)
         videoCodecSelection.name.text = "映像コーデック"
         videoCodecSelection.spinner.setItems(videoCodecOptions)
         videoEnabledSelection.name.text = "映像の有無"
@@ -79,6 +85,8 @@ class SpotlightRoomSetupActivity : AppCompatActivity() {
         val spotlightNumber = selectedItem(spotlightNumberSelection.spinner)
         val role = selectedItem(roleSelection.spinner)
         val legacy = selectedItem(legacySelection.spinner)
+        var spotlightFocusRid = selectedItem(spotlightFocusRidSelection.spinner)
+        var spotlightUnfocusRid = selectedItem(spotlightUnfocusRidSelection.spinner)
         val videoCodec = selectedItem(videoCodecSelection.spinner)
         val audioCodec = selectedItem(audioCodecSelection.spinner)
         val audioBitRate = selectedItem(audioBitRateSelection.spinner)
@@ -96,6 +104,8 @@ class SpotlightRoomSetupActivity : AppCompatActivity() {
         intent.putExtra("SPOTLIGHT", "有効")
         intent.putExtra("SPOTLIGHT_NUMBER", spotlightNumber)
         intent.putExtra("SPOTLIGHT_LEGACY", legacy)
+        intent.putExtra("SPOTLIGHT_FOCUS_RID", spotlightFocusRid)
+        intent.putExtra("SPOTLIGHT_UNFOCUS_RID", spotlightUnfocusRid)
         intent.putExtra("ROLE", role)
         intent.putExtra("LEGACY", legacy)
         intent.putExtra("VIDEO_CODEC", videoCodec)

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/SpotlightRoomSetupActivity.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/SpotlightRoomSetupActivity.kt
@@ -49,9 +49,9 @@ class SpotlightRoomSetupActivity : AppCompatActivity() {
         roleSelection.spinner.setItems(roleOptions)
         legacySelection.name.text = "レガシー機能"
         legacySelection.spinner.setItems(legacyOptions)
-        spotlightFocusRidSelection.name.text = "フォーカス時の RID"
+        spotlightFocusRidSelection.name.text = "フォーカス時の rid"
         spotlightFocusRidSelection.spinner.setItems(spotlightFocusRidOptions)
-        spotlightUnfocusRidSelection.name.text = "非フォーカス時の RID"
+        spotlightUnfocusRidSelection.name.text = "非フォーカス時の rid"
         spotlightUnfocusRidSelection.spinner.setItems(spotlightUnfocusRidOptions)
         videoCodecSelection.name.text = "映像コーデック"
         videoCodecSelection.spinner.setItems(videoCodecOptions)

--- a/samples/src/main/res/layout/activity_simulcast_setup.xml
+++ b/samples/src/main/res/layout/activity_simulcast_setup.xml
@@ -80,11 +80,13 @@
                     android:id="@+id/audioStereoSelection"/>
                 <include
                     layout="@layout/signaling_selection"
+                    android:id="@+id/simulcastRidSelection"/>
+                <include
+                    layout="@layout/signaling_selection"
                     android:id="@+id/dataChannelSignalingSelection"/>
                 <include
                     layout="@layout/signaling_selection"
                     android:id="@+id/ignoreDisconnectWebSocketSelection"/>
-
             </com.google.android.material.textfield.TextInputLayout>
 
         </LinearLayout>

--- a/samples/src/main/res/layout/activity_spotlight_room_setup.xml
+++ b/samples/src/main/res/layout/activity_spotlight_room_setup.xml
@@ -78,6 +78,12 @@
                     android:id="@+id/audioBitRateSelection"/>
                 <include
                     layout="@layout/signaling_selection"
+                    android:id="@+id/spotlightFocusRidSelection"/>
+                <include
+                    layout="@layout/signaling_selection"
+                    android:id="@+id/spotlightUnfocusRidSelection"/>
+                <include
+                    layout="@layout/signaling_selection"
                     android:id="@+id/dataChannelSignalingSelection"/>
                 <include
                     layout="@layout/signaling_selection"


### PR DESCRIPTION
## 変更内容

- サイマルキャスト画面から simulcast_rid を指定可能にしました
- スポットライト画面から spotlight_focus_rid / spotlight_unfocus_rid を指定しました

## 相談したい内容

- 追加した設定項目のラベル名
- 動作確認に利用した Pixel 4 では `非フォーカス時の RID` というラベルがはみ出してしまっている
  - RID を小文字にして改善 https://github.com/shiguredo/sora-android-sdk-samples/pull/32#issuecomment-876093610 

<img src="https://user-images.githubusercontent.com/17097142/124854656-9e843700-dfe2-11eb-89b5-d42aa9afd347.png" width="280" />

## 共有事項

動作確認には sora-android-sdk の以下のブランチを参照する必要があります
https://github.com/shiguredo/sora-android-sdk/pull/46

## 動作確認した内容

- サイマルキャストで simulcast_rid が指定できる
  - signaling.log から確認
- スポットライトで spotlight_focus_rid / spotlight_unfocus_rid を指定できる
  - signaling.log から確認
- スポットライト・レガシーで Sora に接続できる
  - その際、シグナリング・メッセージに spotlight_focus_rid / spotlight_unfocus_rid が含まれていない