### PR TITLE
gradle.properties で指定した usesCleartextTraffic が参照されない問題を修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,7 +20,7 @@
 ### FIX
 
 - 自身の映像プレビューが反転している問題を修正する
-- gradle.properties で指定した usesCleartextTraffic が参照されない問題を修正する
+- gradle.properties で指定した usesCleartextTraffic が参照されずに、常に true になっていた問題を修正する
 
 ### UPDATE
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@
 ### FIX
 
 - 自身の映像プレビューが反転している問題を修正する
+- gradle.properties で指定した usesCleartextTraffic が参照されない問題を修正する
 
 ### UPDATE
 

--- a/samples/build.gradle
+++ b/samples/build.gradle
@@ -17,8 +17,7 @@ android {
         buildConfigField("String", "SIGNALING_ENDPOINT", "\"${signaling_endpoint}\"")
         resValue("string", "channelId", "\"${channel_id}\"")
 
-        // サイマルキャストで HTTP API を利用するので HTTP 通信を許可する
-        manifestPlaceholders = [usesCleartextTraffic: true];
+        manifestPlaceholders = [usesCleartextTraffic: usesCleartextTraffic];
     }
 
     compileOptions {


### PR DESCRIPTION
## 変更内容

- gradle.properties で指定した usesCleartextTraffic が参照されない問題を修正しました

## 参考

- sora-android-sdk-quickstart https://github.com/shiguredo/sora-android-sdk-quickstart/search?q=usesCleartextTraffic
- sora-android-sdk-samples https://github.com/shiguredo/sora-android-sdk-samples/search?q=usesCleartextTraffic