### PR TITLE
Feature/remove jcenter dependencies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,14 @@
 
 ## develop
 
+### UPDATE
+
+- sdk が channel_id を必須にした変更に追従する
+- spotlight_number は未指定をデフォルトにする
+- 依存ライブラリーのバージョンを上げる
+  - `com.android.tools.build:gradle` を 4.2.2 に上げる
+- jCenter への参照を取り除く
+
 ## ADD
 
 - サイマルキャストの接続時に simulcast_rid を指定できるようにする
@@ -26,10 +34,6 @@
 - 自身の映像プレビューが反転している問題を修正する
 - gradle.properties で指定した usesCleartextTraffic が参照されずに、常に true になっていた問題を修正する
 
-### UPDATE
-
-- sdk が channel_id を必須にした変更に追従する
-- spotlight_number は未指定をデフォルトにする
 =======
 ## sora-android-sdk-2021.1.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,7 @@
 - spotlight_number は未指定をデフォルトにする
 - 依存ライブラリーのバージョンを上げる
   - `com.android.tools.build:gradle` を 4.2.2 に上げる
-- jCenter への参照を取り除く
+- JCenter への参照を取り除く
 
 ## ADD
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:4.2.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,9 @@ buildscript {
     ext.sora_android_sdk_version = '2021.1.1'
 
     repositories {
-        jcenter()
         google()
         gradlePluginPortal()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.2'
@@ -27,9 +27,9 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         google()
         maven { url 'https://jitpack.io' }
+        mavenCentral()
     }
 }
 

--- a/samples/build.gradle
+++ b/samples/build.gradle
@@ -72,8 +72,8 @@ dependencies {
     implementation 'androidx.navigation:navigation-ui-ktx:2.3.3'
 
     ext.pd_version = '4.8.0'
-    implementation "org.permissionsdispatcher:permissionsdispatcher:${pd_version}"
-    kapt "org.permissionsdispatcher:permissionsdispatcher-processor:${pd_version}"
+    implementation "com.github.permissions-dispatcher:permissionsdispatcher:${pd_version}"
+    kapt "com.github.permissions-dispatcher:permissionsdispatcher-processor:${pd_version}"
 
     implementation project(path: ':webrtc-video-effector')
 }

--- a/samples/build.gradle
+++ b/samples/build.gradle
@@ -72,7 +72,7 @@ dependencies {
     implementation 'androidx.navigation:navigation-ui-ktx:2.3.3'
 
     ext.pd_version = '4.8.0'
-    implementation "com.github.permissions-dispatcher:permissionsdispatcher:${pd_version}"
+    implementation "com.github.permissions-dispatcher.permissionsdispatcher:permissionsdispatcher:${pd_version}"
     kapt "com.github.permissions-dispatcher:permissionsdispatcher-processor:${pd_version}"
 
     implementation project(path: ':webrtc-video-effector')


### PR DESCRIPTION
## 変更内容

- JCenter への参照を取り除きました
- `com.android.tools.build:gradle` を 4.2.2 に更新しました

## 確認

ビルド後、以下のコマンドで jcenter を参照している箇所がないことを確認しました

```
$ grep -ir jcenter . | grep -v -e '\.idea' -e '.\git'
```