### PR TITLE
permissions-dispatcher を Maven Central から取得する

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,8 @@ buildscript {
 allprojects {
     repositories {
         google()
-        maven { url 'https://jitpack.io' }
         mavenCentral()
+        maven { url 'https://jitpack.io' }
     }
 }
 

--- a/samples/build.gradle
+++ b/samples/build.gradle
@@ -72,7 +72,7 @@ dependencies {
     implementation 'androidx.navigation:navigation-ui-ktx:2.3.3'
 
     ext.pd_version = '4.8.0'
-    implementation "com.github.permissions-dispatcher.permissionsdispatcher:permissionsdispatcher:${pd_version}"
+    implementation "com.github.permissions-dispatcher:permissionsdispatcher:${pd_version}"
     kapt "com.github.permissions-dispatcher:permissionsdispatcher-processor:${pd_version}"
 
     implementation project(path: ':webrtc-video-effector')


### PR DESCRIPTION
## 変更内容

- permissions-dispatcher を Maven Central から取得するように修正しました
  - 修正前は permissions-dispatcher を JitPack から取得していました