### PR TITLE
sendrecv 接続時に映像の送信を無効に設定し、かつ相手が H.264 の映像を送信するとき接続が失敗する不具合を修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,10 @@
 - FIX
     - バグ修正
 
+## develop
+
+- [FIX] sendrecv 接続時に映像の送信を無効に設定し、かつ相手が H.264 の映像を送信するとき接続が失敗する不具合を修正する
+  - @miosakuma
 
 ## sora-android-sdk-2021.2
 

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/facade/SoraVideoChannel.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/facade/SoraVideoChannel.kt
@@ -235,7 +235,7 @@ class SoraVideoChannel(
                 if (audioEnabled) {
                     enableAudioDownstream()
                 }
-                if (videoEnabled) {
+                if (videoEnabled || role == SoraRoleType.SENDRECV) {
                     enableVideoDownstream(egl!!.eglBaseContext)
                 }
             }


### PR DESCRIPTION
### 修正内容

ビデオチャットサンプルから映像の有無：無効をして接続した時、相手の codec が H.264 だとサンプルの接続がエラーとなる事象について対応しました。

Android SDK 側は `SoraMediaOption.videoDownstreamContext` が未設定の場合は `SoftwareVideoEncoderFactory` を使用するようになっていましたが、H.264 は `SoftwareVideoEncoderFactory` で扱えないためにエラーとなっていました。
https://github.com/shiguredo/sora-android-sdk/blob/develop/sora-android-sdk/src/main/kotlin/jp/shiguredo/sora/sdk/channel/rtc/RTCComponentFactory.kt#L45-L55

`SoraMediaOption.videoDownstreamContext` が未設定なのは、ビデオチャットサンプルにて`映像の有無`を`無効`に設定した場合に`SoraMediaOption.videoDownstreamContext` を設定しない動作となっていたため、これを修正しています。
~~音声についても同様に修正をしています。~~

### 追記

ボイスチャットサンプルについても同様の事象が発生していますがこの PR では未対応です。
双方とも映像を無効にすることを想定したサンプルであるため、対応は行っていません。
