### PR TITLE
Sora との接続時に connectedSignalingEndpoint を出力する

### DIFF
--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/facade/SoraAudioChannel.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/facade/SoraAudioChannel.kt
@@ -42,7 +42,7 @@ class SoraAudioChannel(
     private val channelListener = object : SoraMediaChannel.Listener {
 
         override fun onConnect(mediaChannel: SoraMediaChannel) {
-            SoraLogger.d(TAG, "[audio_channel] @onConnected")
+            SoraLogger.d(TAG, "[audio_channel] @onConnect connectedSignalingEndpoint:${mediaChannel.connectedSignalingEndpoint}")
             handler.post { listener?.onConnect(this@SoraAudioChannel) }
         }
 

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/facade/SoraVideoChannel.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/facade/SoraVideoChannel.kt
@@ -15,7 +15,6 @@ import jp.shiguredo.sora.sdk.util.SoraLogger
 import org.webrtc.*
 import android.os.Handler
 import jp.shiguredo.sora.sample.stats.VideoUpstreamLatencyStatsCollector
-import jp.shiguredo.sora.sdk.Sora
 import jp.shiguredo.sora.sdk.channel.option.*
 
 class SoraVideoChannel(
@@ -76,7 +75,7 @@ class SoraVideoChannel(
     private val channelListener = object : SoraMediaChannel.Listener {
 
         override fun onConnect(mediaChannel: SoraMediaChannel) {
-            SoraLogger.d(TAG, "[video_channel] @onConnected")
+            SoraLogger.d(TAG, "[video_channel] @onConnect connectedSignalingEndpoint:${mediaChannel.connectedSignalingEndpoint}")
             handler.post {
                 listener?.onConnect(this@SoraVideoChannel)
             }


### PR DESCRIPTION
## 変更内容

- Sora との接続時に connectedSignalingEndpoint を出力するように修正しました
  - SDK 側の https://github.com/shiguredo/sora-android-sdk/pull/65 に対応する変更です