### PR TITLE
シグナリング接続時に送信するメタデータを外部ファイルから設定できるようにする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 
 ## develop
 
+- [ADD] シグナリング接続時に送信するメタデータを外部ファイルから設定できるようにする
+  - @miosakuma
 - [CHANGE] スポットライトレガシーを削除する
   - @enm10k
 - [CHANGE] シグナリングの URL指定を `signaling_endpoint` から `signalingEndpointCandidates` に変更する

--- a/gradle.properties.example
+++ b/gradle.properties.example
@@ -24,8 +24,8 @@ android.useAndroidX=true
 signaling_endpoint = wss://sora.example.com/signaling
 channel_id         = sora
 
-# Setting for connecting Sora Labo.
+# Setting Signaling Metadata.
 # Quotes must be double escaped.
+# e.g.) signaling_metadata = {\\"spam\\":\\"egg\\"}
 # This setting is required. If you do not want to use it, set it to blank.
-# e.g.) signaling_metadata =
-signaling_metadata = {\\"signaling_key\\":\\"YourSingalingKeyOfSoraLabo\\"}
+signaling_metadata =

--- a/gradle.properties.example
+++ b/gradle.properties.example
@@ -24,3 +24,8 @@ android.useAndroidX=true
 signaling_endpoint = wss://sora.example.com/signaling
 channel_id         = sora
 
+# Setting for connecting Sora Labo.
+# Quotes must be double escaped.
+# This setting is required. If you do not want to use it, set it to blank.
+# e.g.) signaling_metadata =
+signaling_metadata = {\\"signaling_key\\":\\"YourSingalingKeyOfSoraLabo\\"}

--- a/samples/build.gradle
+++ b/samples/build.gradle
@@ -16,6 +16,7 @@ android {
         // アプリで参照する設定を BuildConfig / resource に書き込む。
         buildConfigField("String", "SIGNALING_ENDPOINT", "\"${signaling_endpoint}\"")
         resValue("string", "channelId", "\"${channel_id}\"")
+        buildConfigField("String", "SIGNALING_METADATA", "\"${signaling_metadata}\"")
 
         manifestPlaceholders = [usesCleartextTraffic: usesCleartextTraffic];
     }
@@ -60,6 +61,8 @@ configurations {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${kotlin_version}"
     implementation "org.jetbrains.kotlin:kotlin-reflect:${kotlin_version}"
+
+    implementation 'com.google.code.gson:gson:2.8.6'
 
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation "androidx.cardview:cardview:1.0.0"

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/facade/SoraAudioChannel.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/facade/SoraAudioChannel.kt
@@ -21,7 +21,7 @@ class SoraAudioChannel(
         private val channelId:                      String,
         private val dataChannelSignaling:           Boolean? = null,
         private val ignoreDisconnectWebSocket:      Boolean? = null,
-        private val signalingMetadata:              String = "",
+        private val signalingMetadata:              Any? = "",
         private var role:                           SoraRoleType,
         private var multistream:                    Boolean = true,
         private var audioCodec:                     SoraAudioOption.Codec = SoraAudioOption.Codec.OPUS,

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/screencast/SoraScreencastService.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/screencast/SoraScreencastService.kt
@@ -26,6 +26,8 @@ import jp.shiguredo.sora.sdk.error.SoraErrorReason
 import jp.shiguredo.sora.sdk.util.SoraLogger
 import kotlinx.android.synthetic.main.screencast_service.view.*
 import org.webrtc.*
+import com.google.gson.*
+
 
 @TargetApi(21)
 class SoraScreencastService : Service() {
@@ -262,11 +264,12 @@ class SoraScreencastService : Service() {
         }
 
         val signalingEndpointCandidates = req!!.signalingEndpoint!!.split(",").map{ it.trim() }
+        val signalingMetadata = Gson().fromJson(req!!.signalingMetadata!!, Map::class.java)
         mediaChannel = SoraMediaChannel(
                 context           = this,
                 signalingEndpointCandidates = signalingEndpointCandidates,
                 channelId         = req!!.channelId,
-                signalingMetadata = req!!.signalingMetadata!!,
+                signalingMetadata = signalingMetadata,
                 mediaOption       = mediaOption,
                 listener          = channelListener
         )

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/EffectedVideoChatActivity.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/EffectedVideoChatActivity.kt
@@ -9,11 +9,12 @@ import android.media.effect.EffectFactory
 import android.os.Build
 import android.os.Bundle
 import android.os.Handler
-import androidx.appcompat.app.AppCompatActivity
 import android.util.Log
 import android.view.View
 import android.view.WindowManager
 import android.widget.*
+import androidx.appcompat.app.AppCompatActivity
+import com.google.gson.*
 import jp.co.cyberagent.android.gpuimage.filter.*
 import jp.shiguredo.sora.sample.BuildConfig
 import jp.shiguredo.sora.sample.R
@@ -29,7 +30,6 @@ import jp.shiguredo.webrtc.video.effector.VideoEffectorContext
 import jp.shiguredo.webrtc.video.effector.filter.GPUImageFilterWrapper
 import kotlinx.android.synthetic.main.activity_video_chat_room.*
 import org.webrtc.SurfaceViewRenderer
-import com.google.gson.*
 
 class EffectedVideoChatActivity : AppCompatActivity() {
 

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/EffectedVideoChatActivity.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/EffectedVideoChatActivity.kt
@@ -29,6 +29,7 @@ import jp.shiguredo.webrtc.video.effector.VideoEffectorContext
 import jp.shiguredo.webrtc.video.effector.filter.GPUImageFilterWrapper
 import kotlinx.android.synthetic.main.activity_video_chat_room.*
 import org.webrtc.SurfaceViewRenderer
+import com.google.gson.*
 
 class EffectedVideoChatActivity : AppCompatActivity() {
 
@@ -189,12 +190,13 @@ class EffectedVideoChatActivity : AppCompatActivity() {
     private fun connectChannel() {
         Log.d(TAG, "connectChannel")
         val signalingEndpointCandidates = BuildConfig.SIGNALING_ENDPOINT.split(",").map{ it.trim() }
+        val signalingMetadata = Gson().fromJson(BuildConfig.SIGNALING_METADATA, Map::class.java)
         channel = SoraVideoChannel(
                 context                     = this,
                 handler                     = Handler(),
                 signalingEndpointCandidates = signalingEndpointCandidates,
                 channelId                   = channelName,
-                signalingMetadata           = "",
+                signalingMetadata           = signalingMetadata,
                 videoWidth                  = 480,
                 videoHeight                 = 960,
                 videoFPS                    = 30,

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/ScreencastSetupActivity.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/ScreencastSetupActivity.kt
@@ -3,21 +3,16 @@ package jp.shiguredo.sora.sample.ui
 import android.annotation.TargetApi
 import android.content.Intent
 import android.os.Bundle
-import com.google.android.material.snackbar.Snackbar
+import android.util.Log
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
-import android.util.Log
+import com.google.android.material.snackbar.Snackbar
 import com.jaredrummler.materialspinner.MaterialSpinner
 import jp.shiguredo.sora.sample.BuildConfig
 import jp.shiguredo.sora.sample.R
 import jp.shiguredo.sora.sample.screencast.SoraScreencastService
 import jp.shiguredo.sora.sample.screencast.SoraScreencastServiceStarter
-import kotlinx.android.synthetic.main.activity_screencast_setup.audioCodecSelection
-import kotlinx.android.synthetic.main.activity_screencast_setup.channelNameInput
-import kotlinx.android.synthetic.main.activity_screencast_setup.multistreamSelection
-import kotlinx.android.synthetic.main.activity_screencast_setup.rootLayout
-import kotlinx.android.synthetic.main.activity_screencast_setup.start
-import kotlinx.android.synthetic.main.activity_screencast_setup.videoCodecSelection
+import kotlinx.android.synthetic.main.activity_screencast_setup.*
 import kotlinx.android.synthetic.main.signaling_selection.view.*
 
 @TargetApi(21)

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/ScreencastSetupActivity.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/ScreencastSetupActivity.kt
@@ -75,7 +75,7 @@ class ScreencastSetupActivity : AppCompatActivity() {
         screencastStarter = SoraScreencastServiceStarter(
                 activity          = this,
                 signalingEndpoint = BuildConfig.SIGNALING_ENDPOINT,
-                signalingMetadata = "",
+                signalingMetadata = BuildConfig.SIGNALING_METADATA,
                 channelId         = channelId,
                 videoCodec        = videoCodec,
                 audioCodec        = audioCodec,

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/SimulcastActivity.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/SimulcastActivity.kt
@@ -10,11 +10,12 @@ import android.media.AudioManager
 import android.os.Build
 import android.os.Bundle
 import android.os.Handler
-import androidx.appcompat.app.AppCompatActivity
 import android.util.Log
 import android.view.View
 import android.view.WindowManager
 import android.widget.*
+import androidx.appcompat.app.AppCompatActivity
+import com.google.gson.*
 import jp.shiguredo.sora.sample.BuildConfig
 import jp.shiguredo.sora.sample.R
 import jp.shiguredo.sora.sample.facade.SoraVideoChannel
@@ -27,17 +28,8 @@ import jp.shiguredo.sora.sdk.channel.option.SoraVideoOption
 import jp.shiguredo.sora.sdk.error.SoraErrorReason
 import jp.shiguredo.sora.sdk.util.SoraLogger
 import kotlinx.android.synthetic.main.activity_simulcast.*
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.webrtc.SurfaceViewRenderer
-import java.io.BufferedOutputStream
-import java.net.HttpURLConnection
-import java.net.URI
-import java.net.URL
 import java.util.*
-import com.google.gson.*
 
 
 class SimulcastActivity : AppCompatActivity() {

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/SimulcastActivity.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/SimulcastActivity.kt
@@ -37,6 +37,8 @@ import java.net.HttpURLConnection
 import java.net.URI
 import java.net.URL
 import java.util.*
+import com.google.gson.*
+
 
 class SimulcastActivity : AppCompatActivity() {
 
@@ -307,6 +309,7 @@ class SimulcastActivity : AppCompatActivity() {
     private fun connectChannel() {
         Log.d(TAG, "openChannel")
         val signalingEndpointCandidates = BuildConfig.SIGNALING_ENDPOINT.split(",").map{ it.trim() }
+        val signalingMetadata = Gson().fromJson(BuildConfig.SIGNALING_METADATA, Map::class.java)
         channel = SoraVideoChannel(
             context                     = this,
             handler                     = Handler(),
@@ -314,7 +317,7 @@ class SimulcastActivity : AppCompatActivity() {
             channelId                   = channelName,
             dataChannelSignaling        = dataChannelSignaling,
             ignoreDisconnectWebSocket   = ignoreDisconnectWebSocket,
-            signalingMetadata           = "",
+            signalingMetadata           = signalingMetadata,
             spotlight                   = spotlight,
             spotlightNumber             = spotlightNumber,
             spotlightFocusRid           = spotlightFocusRid,

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/VideoChatRoomActivity.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/VideoChatRoomActivity.kt
@@ -29,6 +29,7 @@ import jp.shiguredo.sora.sdk.util.SoraLogger
 import kotlinx.android.synthetic.main.activity_video_chat_room.*
 import org.webrtc.SurfaceViewRenderer
 import java.util.*
+import com.google.gson.*
 
 class VideoChatRoomActivity : AppCompatActivity() {
 
@@ -291,12 +292,13 @@ class VideoChatRoomActivity : AppCompatActivity() {
     private fun connectChannel() {
         Log.d(TAG, "openChannel")
         val signalingEndpointCandidates = BuildConfig.SIGNALING_ENDPOINT.split(",").map{ it.trim() }
+        val signalingMetadata = Gson().fromJson(BuildConfig.SIGNALING_METADATA, Map::class.java)
         channel = SoraVideoChannel(
                 context           = this,
                 handler           = Handler(),
                 signalingEndpointCandidates = signalingEndpointCandidates,
                 channelId         = channelName,
-                signalingMetadata = "",
+                signalingMetadata = signalingMetadata,
                 dataChannelSignaling = dataChannelSignaling,
                 ignoreDisconnectWebSocket = ignoreDisconnectWebSocket,
                 spotlight         = spotlight,

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/VoiceChatRoomActivity.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/VoiceChatRoomActivity.kt
@@ -19,6 +19,8 @@ import jp.shiguredo.sora.sdk.channel.data.ChannelAttendeesCount
 import jp.shiguredo.sora.sdk.channel.option.SoraAudioOption
 import jp.shiguredo.sora.sdk.error.SoraErrorReason
 import kotlinx.android.synthetic.main.activity_voice_chat_room.*
+import com.google.gson.*
+
 
 class VoiceChatRoomActivity : AppCompatActivity() {
 
@@ -154,6 +156,7 @@ class VoiceChatRoomActivity : AppCompatActivity() {
     private fun connectChannel() {
         Log.d(TAG, "connectChannel")
         val signalingEndpointCandidates = BuildConfig.SIGNALING_ENDPOINT.split(",").map{ it.trim() }
+        val signalingMetadata = Gson().fromJson(BuildConfig.SIGNALING_METADATA, Map::class.java)
         channel = SoraAudioChannel(
                 context                     = this,
                 handler                     = Handler(),
@@ -161,7 +164,7 @@ class VoiceChatRoomActivity : AppCompatActivity() {
                 channelId                   = channelName,
                 dataChannelSignaling        = dataChannelSignaling,
                 ignoreDisconnectWebSocket   = ignoreDisconnectWebSocket,
-                signalingMetadata           = "",
+                signalingMetadata           = signalingMetadata,
                 audioCodec                  = audioCodec,
                 audioBitRate                = audioBitRate,
                 role                        = role,


### PR DESCRIPTION
概要
---

シグナリングで送信するメタデータについて外部ファイルから設定ができるようにしました。
`signaling_metadata` という項目名で追加をしています。
今まで SoraLabo と Android Samples を接続するにはプログラムの修正が必要でしたが今後は不要となり、
気軽に Android Samples を試してもらえるようになると思います。

修正箇所についての補足
---

- 外部ファイルに設定をするにあたり、二重にエスケープをする必要が出ています。外部ファイルには設定例を記載しています。
`build.gradle` でのクラスファイル生成時、Gsonで文字列を map に変換時の2回エスケープが必要だったためです。
https://github.com/shiguredo/sora-android-sdk-samples/compare/feature/add-signaling-metadata-setting?expand=1#diff-bbb7dbbc87a5eeefd96280835e68694ed252637b5b87bce74364c0e4ea56bca4R28-R29

- 設定内容が空、null であった時の Sora への送信内容は以下の通りでした。
  - `signaling_metadata` 自体を設定しない -> ビルドエラー
  - `signaling_metadata =` を設定 -> map が null となり、Sora に metadata が送信されない
  - `signaling_metadata ={}` を設定 -> Sora に `"metadata": {}` を送信