### PR TITLE
解像度に Landscape と Portrait の両方を追加する & Landscape と Portrait の優先度を変える

### DIFF
--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/option/SoraFrameSize.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/option/SoraFrameSize.kt
@@ -11,9 +11,9 @@ class SoraFrameSize {
             "VGA: 640x480" to SoraVideoOption.FrameSize.Landscape.VGA,
             "HD: 1280x720" to SoraVideoOption.FrameSize.Landscape.HD,
             "FHD: 1920x1080" to SoraVideoOption.FrameSize.Landscape.FHD,
-            "Res3840x1920" to SoraVideoOption.FrameSize.Landscape.Res3840x1920,
-            "UHD3840x2160" to SoraVideoOption.FrameSize.Landscape.UHD3840x2160,
-            "UHD4096x2160" to SoraVideoOption.FrameSize.Landscape.UHD4096x2160,
+            "3840x1920" to SoraVideoOption.FrameSize.Landscape.Res3840x1920,
+            "UHD: 3840x2160" to SoraVideoOption.FrameSize.Landscape.UHD3840x2160,
+            "4096x2160" to SoraVideoOption.FrameSize.Landscape.UHD4096x2160,
         )
         val portrait = mapOf(
             "QCIF: 144x176" to SoraVideoOption.FrameSize.Portrait.QCIF,
@@ -22,9 +22,9 @@ class SoraFrameSize {
             "VGA: 480x640" to SoraVideoOption.FrameSize.Portrait.VGA,
             "HD: 720x1280" to SoraVideoOption.FrameSize.Portrait.HD,
             "FHD: 1080x1920" to SoraVideoOption.FrameSize.Portrait.FHD,
-            "Res3840x1920" to SoraVideoOption.FrameSize.Portrait.Res1920x3840,
-            "UHD3840x2160" to SoraVideoOption.FrameSize.Portrait.UHD2160x3840,
-            "UHD4096x2160" to SoraVideoOption.FrameSize.Portrait.UHD2160x4096,
+            "3840x1920" to SoraVideoOption.FrameSize.Portrait.Res1920x3840,
+            "UHD: 3840x2160" to SoraVideoOption.FrameSize.Portrait.UHD2160x3840,
+            "4096x2160" to SoraVideoOption.FrameSize.Portrait.UHD2160x4096,
         )
 
         val all = landscape + portrait

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/option/SoraFrameSize.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/option/SoraFrameSize.kt
@@ -4,8 +4,7 @@ import jp.shiguredo.sora.sdk.channel.option.SoraVideoOption
 
 class SoraFrameSize {
     companion object {
-        // NOTE:
-        /**
+        /*
          * NOTE: Kotlin の Map は順序保証あり
          *
          * > Entries of the map are iterated in the order they were specified.

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/option/SoraFrameSize.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/option/SoraFrameSize.kt
@@ -1,0 +1,32 @@
+package jp.shiguredo.sora.sample.option
+
+import jp.shiguredo.sora.sdk.channel.option.SoraVideoOption
+
+class SoraFrameSize {
+    companion object {
+        val landscape = mapOf(
+            "QCIF: 176x144" to SoraVideoOption.FrameSize.Landscape.QCIF,
+            "HQVGA: 240x160" to SoraVideoOption.FrameSize.Landscape.HQVGA,
+            "QVGA: 320x240" to SoraVideoOption.FrameSize.Landscape.QVGA,
+            "VGA: 640x480" to SoraVideoOption.FrameSize.Landscape.VGA,
+            "HD: 1280x720" to SoraVideoOption.FrameSize.Landscape.HD,
+            "FHD: 1920x1080" to SoraVideoOption.FrameSize.Landscape.FHD,
+            "Res3840x1920" to SoraVideoOption.FrameSize.Landscape.Res3840x1920,
+            "UHD3840x2160" to SoraVideoOption.FrameSize.Landscape.UHD3840x2160,
+            "UHD4096x2160" to SoraVideoOption.FrameSize.Landscape.UHD4096x2160,
+        )
+        val portrait = mapOf(
+            "QCIF: 144x176" to SoraVideoOption.FrameSize.Portrait.QCIF,
+            "HQVGA: 160x240" to SoraVideoOption.FrameSize.Portrait.HQVGA,
+            "QVGA: 240x320" to SoraVideoOption.FrameSize.Portrait.QVGA,
+            "VGA: 480x640" to SoraVideoOption.FrameSize.Portrait.VGA,
+            "HD: 720x1280" to SoraVideoOption.FrameSize.Portrait.HD,
+            "FHD: 1080x1920" to SoraVideoOption.FrameSize.Portrait.FHD,
+            "Res3840x1920" to SoraVideoOption.FrameSize.Portrait.Res1920x3840,
+            "UHD3840x2160" to SoraVideoOption.FrameSize.Portrait.UHD2160x3840,
+            "UHD4096x2160" to SoraVideoOption.FrameSize.Portrait.UHD2160x4096,
+        )
+
+        val all = landscape + portrait
+    }
+}

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/option/SoraFrameSize.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/option/SoraFrameSize.kt
@@ -4,6 +4,13 @@ import jp.shiguredo.sora.sdk.channel.option.SoraVideoOption
 
 class SoraFrameSize {
     companion object {
+        // NOTE:
+        /**
+         * NOTE: Kotlin の Map は順序保証あり
+         *
+         * > Entries of the map are iterated in the order they were specified.
+         * https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/map-of.html
+         */
         val landscape = mapOf(
             "QCIF: 176x144" to SoraVideoOption.FrameSize.Landscape.QCIF,
             "HQVGA: 240x160" to SoraVideoOption.FrameSize.Landscape.HQVGA,

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/SimulcastActivity.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/SimulcastActivity.kt
@@ -22,6 +22,7 @@ import jp.shiguredo.sora.sample.BuildConfig
 import jp.shiguredo.sora.sample.R
 import jp.shiguredo.sora.sample.databinding.ActivitySimulcastBinding
 import jp.shiguredo.sora.sample.facade.SoraVideoChannel
+import jp.shiguredo.sora.sample.option.SoraFrameSize
 import jp.shiguredo.sora.sample.option.SoraRoleType
 import jp.shiguredo.sora.sample.ui.util.RendererLayoutCalculator
 import jp.shiguredo.sora.sample.ui.util.SoraScreenUtil
@@ -102,26 +103,12 @@ class SimulcastActivity : AppCompatActivity() {
 
         fps = (intent.getStringExtra("FPS") ?: "30").toInt()
 
-        var videoSize = when (intent.getStringExtra("VIDEO_SIZE")) {
-            // Portrait
-            "VGA" -> SoraVideoOption.FrameSize.Portrait.VGA
-            "QQVGA" -> SoraVideoOption.FrameSize.Portrait.QQVGA
-            "QCIF" -> SoraVideoOption.FrameSize.Portrait.QCIF
-            "HQVGA" -> SoraVideoOption.FrameSize.Portrait.HQVGA
-            "QVGA" -> SoraVideoOption.FrameSize.Portrait.QVGA
-            "HD" -> SoraVideoOption.FrameSize.Portrait.HD
-            "FHD" -> SoraVideoOption.FrameSize.Portrait.FHD
-            "Res1920x3840" -> SoraVideoOption.FrameSize.Portrait.Res1920x3840
-            "UHD2160x3840" -> SoraVideoOption.FrameSize.Portrait.UHD2160x3840
-            "UHD2160x4096" -> SoraVideoOption.FrameSize.Portrait.UHD2160x4096
-            // Landscape
-            "Res3840x1920" -> SoraVideoOption.FrameSize.Landscape.Res3840x1920
-            "UHD3840x2160" -> SoraVideoOption.FrameSize.Landscape.UHD3840x2160
-            // Default
-            else -> SoraVideoOption.FrameSize.Portrait.VGA
+        intent.getStringExtra("VIDEO_SIZE")?.let { key ->
+            SoraFrameSize.all[key]?.let { p ->
+                videoWidth = p.x
+                videoHeight = p.y
+            }
         }
-        videoWidth = videoSize.x
-        videoHeight = videoSize.y
 
         multistream = when (intent.getStringExtra("MULTISTREAM")) {
             "有効" -> true

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/SimulcastSetupActivity.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/SimulcastSetupActivity.kt
@@ -7,6 +7,7 @@ import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.snackbar.Snackbar
 import com.jaredrummler.materialspinner.MaterialSpinner
 import jp.shiguredo.sora.sample.databinding.ActivitySimulcastSetupBinding
+import jp.shiguredo.sora.sample.option.SoraFrameSize
 
 class SimulcastSetupActivity : AppCompatActivity() {
 
@@ -27,13 +28,7 @@ class SimulcastSetupActivity : AppCompatActivity() {
     private val multistreamOptions = listOf("有効", "無効")
     private val videoBitRateOptions = listOf("200", "500", "700", "1200", "2500", "4000", "5000", "10000", "15000", "20000", "30000")
 
-    private val videoSizeOptions = listOf(
-        // Portrait
-        "VGA", "QQVGA", "QCIF", "HQVGA", "QVGA", "HD", "FHD",
-        "Res1920x3840", "UHD2160x3840", "UHD2160x4096",
-        // Landscape
-        "Res3840x1920", "UHD3840x2160"
-    )
+    private val videoSizeOptions = SoraFrameSize.landscape.keys.toList()
     private val fpsOptions = listOf("30", "10", "15", "20", "24", "60")
     private val resolutionChangeOptions = listOf("可変", "固定")
     private val simulcastRidOptions = listOf("未指定", "r0", "r1", "r2")
@@ -82,7 +77,7 @@ class SimulcastSetupActivity : AppCompatActivity() {
         binding.ignoreDisconnectWebSocketSelection.spinner.setItems(ignoreDisconnectWebSocketOptions)
 
         binding.videoBitRateSelection.spinner.selectedIndex = 6
-        binding.videoSizeSelection.spinner.selectedIndex = 6
+        binding.videoSizeSelection.spinner.selectedIndex = 5
     }
 
     private fun startVideoChat() {

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/SpotlightRoomSetupActivity.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/SpotlightRoomSetupActivity.kt
@@ -7,6 +7,8 @@ import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.snackbar.Snackbar
 import com.jaredrummler.materialspinner.MaterialSpinner
 import jp.shiguredo.sora.sample.databinding.ActivitySpotlightRoomSetupBinding
+import jp.shiguredo.sora.sample.option.SoraFrameSize
+import jp.shiguredo.sora.sdk.channel.option.SoraVideoOption
 
 class SpotlightRoomSetupActivity : AppCompatActivity() {
 
@@ -30,7 +32,10 @@ class SpotlightRoomSetupActivity : AppCompatActivity() {
         "500", "200", "700", "1200", "2500", "4000", "5000",
         "10000", "15000", "20000", "30000"
     )
-    private val videoSizeOptions = listOf("VGA", "QQVGA", "QCIF", "HQVGA", "QVGA", "HD", "FHD")
+    private val videoSizeOptions = SoraFrameSize.landscape.filter {
+        // FHD より大きいものを取り除く
+        it.value.y <= SoraVideoOption.FrameSize.Landscape.FHD.y
+    }.keys.toList()
     private val fpsOptions = listOf("30", "10", "15", "20", "24", "60")
     private val dataChannelSignalingOptions = listOf("未指定", "無効", "有効")
     private val ignoreDisconnectWebSocketOptions = listOf("未指定", "無効", "有効")
@@ -67,6 +72,7 @@ class SpotlightRoomSetupActivity : AppCompatActivity() {
         binding.videoBitRateSelection.spinner.setItems(videoBitRateOptions)
         binding.videoSizeSelection.name.text = "映像サイズ"
         binding.videoSizeSelection.spinner.setItems(videoSizeOptions)
+        binding.videoSizeSelection.spinner.selectedIndex = 3
         binding.fpsSelection.name.text = "フレームレート"
         binding.fpsSelection.spinner.setItems(fpsOptions)
         binding.dataChannelSignalingSelection.name.text = "データチャネル"

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/SpotlightRoomSetupActivity.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/SpotlightRoomSetupActivity.kt
@@ -32,10 +32,7 @@ class SpotlightRoomSetupActivity : AppCompatActivity() {
         "500", "200", "700", "1200", "2500", "4000", "5000",
         "10000", "15000", "20000", "30000"
     )
-    private val videoSizeOptions = SoraFrameSize.landscape.filter {
-        // FHD より大きいものを取り除く
-        it.value.y <= SoraVideoOption.FrameSize.Landscape.FHD.y
-    }.keys.toList()
+    private val videoSizeOptions = SoraFrameSize.landscape.keys.toList()
     private val fpsOptions = listOf("30", "10", "15", "20", "24", "60")
     private val dataChannelSignalingOptions = listOf("未指定", "無効", "有効")
     private val ignoreDisconnectWebSocketOptions = listOf("未指定", "無効", "有効")

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/SpotlightRoomSetupActivity.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/SpotlightRoomSetupActivity.kt
@@ -8,7 +8,6 @@ import com.google.android.material.snackbar.Snackbar
 import com.jaredrummler.materialspinner.MaterialSpinner
 import jp.shiguredo.sora.sample.databinding.ActivitySpotlightRoomSetupBinding
 import jp.shiguredo.sora.sample.option.SoraFrameSize
-import jp.shiguredo.sora.sdk.channel.option.SoraVideoOption
 
 class SpotlightRoomSetupActivity : AppCompatActivity() {
 

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/VideoChatRoomActivity.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/VideoChatRoomActivity.kt
@@ -22,6 +22,7 @@ import jp.shiguredo.sora.sample.BuildConfig
 import jp.shiguredo.sora.sample.R
 import jp.shiguredo.sora.sample.databinding.ActivityVideoChatRoomBinding
 import jp.shiguredo.sora.sample.facade.SoraVideoChannel
+import jp.shiguredo.sora.sample.option.SoraFrameSize
 import jp.shiguredo.sora.sample.option.SoraRoleType
 import jp.shiguredo.sora.sample.ui.util.RendererLayoutCalculator
 import jp.shiguredo.sora.sample.ui.util.SoraScreenUtil
@@ -102,26 +103,12 @@ class VideoChatRoomActivity : AppCompatActivity() {
 
         fps = (intent.getStringExtra("FPS") ?: "30").toInt()
 
-        var videoSize = when (intent.getStringExtra("VIDEO_SIZE")) {
-            // Portrait
-            "VGA" -> SoraVideoOption.FrameSize.Portrait.VGA
-            "QQVGA" -> SoraVideoOption.FrameSize.Portrait.QQVGA
-            "QCIF" -> SoraVideoOption.FrameSize.Portrait.QCIF
-            "HQVGA" -> SoraVideoOption.FrameSize.Portrait.HQVGA
-            "QVGA" -> SoraVideoOption.FrameSize.Portrait.QVGA
-            "HD" -> SoraVideoOption.FrameSize.Portrait.HD
-            "FHD" -> SoraVideoOption.FrameSize.Portrait.FHD
-            "Res1920x3840" -> SoraVideoOption.FrameSize.Portrait.Res1920x3840
-            "UHD2160x3840" -> SoraVideoOption.FrameSize.Portrait.UHD2160x3840
-            "UHD2160x4096" -> SoraVideoOption.FrameSize.Portrait.UHD2160x4096
-            // Landscape
-            "Res3840x1920" -> SoraVideoOption.FrameSize.Landscape.Res3840x1920
-            "UHD3840x2160" -> SoraVideoOption.FrameSize.Landscape.UHD3840x2160
-            // Default
-            else -> SoraVideoOption.FrameSize.Portrait.VGA
+        intent.getStringExtra("VIDEO_SIZE")?.let { key ->
+            SoraFrameSize.all[key]?.let { p ->
+                videoWidth = p.x
+                videoHeight = p.y
+            }
         }
-        videoWidth = videoSize.x
-        videoHeight = videoSize.y
 
         multistream = when (intent.getStringExtra("MULTISTREAM")) {
             "有効" -> true

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/VideoChatRoomSetupActivity.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/VideoChatRoomSetupActivity.kt
@@ -7,6 +7,7 @@ import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.snackbar.Snackbar
 import com.jaredrummler.materialspinner.MaterialSpinner
 import jp.shiguredo.sora.sample.databinding.ActivityVideoChatRoomSetupBinding
+import jp.shiguredo.sora.sample.option.SoraFrameSize
 
 class VideoChatRoomSetupActivity : AppCompatActivity() {
 
@@ -29,13 +30,7 @@ class VideoChatRoomSetupActivity : AppCompatActivity() {
         "未指定", "100", "300", "500", "800", "1000", "1500",
         "2000", "2500", "3000", "5000", "10000", "15000", "20000", "30000"
     )
-    private val videoSizeOptions = listOf(
-        // Portrait
-        "VGA", "QQVGA", "QCIF", "HQVGA", "QVGA", "HD", "FHD",
-        "Res1920x3840", "UHD2160x3840", "UHD2160x4096",
-        // Landscape
-        "Res3840x1920", "UHD3840x2160"
-    )
+    private val videoSizeOptions = SoraFrameSize.all.keys.toList()
     private val fpsOptions = listOf("30", "10", "15", "20", "24", "60")
     private val resolutionChangeOptions = listOf("可変", "固定")
     private val cameraFacingOptions = listOf("前面", "背面")
@@ -74,6 +69,7 @@ class VideoChatRoomSetupActivity : AppCompatActivity() {
         binding.videoBitRateSelection.spinner.setItems(videoBitRateOptions)
         binding.videoSizeSelection.name.text = "映像サイズ"
         binding.videoSizeSelection.spinner.setItems(videoSizeOptions)
+        binding.videoSizeSelection.spinner.selectedIndex = 3
         binding.fpsSelection.name.text = "フレームレート"
         binding.fpsSelection.spinner.setItems(fpsOptions)
         binding.resolutionChangeSelection.name.text = "解像度の変更"


### PR DESCRIPTION
## 変更内容

- ビデオチャット
  - 全ての解像度を指定可能にしました
  - Landscape の解像度が上に表示されます
- サイマルキャストスポットライト
  - 指定できる解像度を Portrait から Landscape に変更しました