### PR TITLE
利用ライブラリをアップデートする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,27 @@
 
 - [UPDATE] 解像度の調整を ON/OFF する UI を追加する
   - @enm10k
+- [UPDATE] compileSdkVersion を 31 に上げる
+  - AndroidManifest.xml の Activity に `android:exported="true"` を明示的に記載する
+- [UPDATE] Gradle のバージョンを 7.4.2 に上げる
+- [UPDATE] Gktlint のバージョンを 0.45.2 に上げる
+- [UPDATE] 依存ライブラリを更新する
+  - com.github.ben-manes:gradle-versions-plugin:0.42.0"
+  - com.google.code.gson:gson を 2.9.0 に上げる  
+  - androidx.appcompat:appcompat を 1.4.2 に上げる
+  - com.google.android.material:material を 1.6.1 に上げる
+  - androidx.constraintlayout:constraintlayout を 2.1.4 に上げる
+  - androidx.navigation:navigation-fragment-ktx を 2.4.2 に上げる
+  - androidx.navigation:navigation-ui-ktx を 2.4.2 に上げる
+  - androidx.compose.ui:ui:1.1.1 に上げる
+  - androidx.compose.material:material を 1.1.1 に上げる
+  - androidx.compose.material:material-icons-extended を 1.1.1 に上げる
+  - androidx.activity:activity-compose を 1.4.0 に上げる
+  - com.github.permissions-dispatcher:permissionsdispatcher を 4.9.2　に上げる
+  - com.android.tools.build:gradle を 7.2.1 に上げる
+  - com.github.ben-manes:gradle-versions-plugin を 0.42.0 に上げる
+  - org.jlleitschuh.gradle:ktlint-gradle を 10.3.0 に上げる
+
 
 ## sora-andoroid-sdk-2022.2.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,8 @@
 - [UPDATE] Gradle のバージョンを 7.4.2 に上げる
 - [UPDATE] Gktlint のバージョンを 0.45.2 に上げる
 - [UPDATE] 依存ライブラリを更新する
-  - com.github.ben-manes:gradle-versions-plugin:0.42.0"
+  - com.android.tools.build:gradle を 7.2.1 に上げる
+  - org.jlleitschuh.gradle:ktlint-gradle を 10.3.0 に上げる
   - com.google.code.gson:gson を 2.9.0 に上げる  
   - androidx.appcompat:appcompat を 1.4.2 に上げる
   - com.google.android.material:material を 1.6.1 に上げる
@@ -30,9 +31,8 @@
   - androidx.compose.material:material-icons-extended を 1.1.1 に上げる
   - androidx.activity:activity-compose を 1.4.0 に上げる
   - com.github.permissions-dispatcher:permissionsdispatcher を 4.9.2　に上げる
-  - com.android.tools.build:gradle を 7.2.1 に上げる
+  - com.github.permissions-dispatcher:permissionsdispatcher-processor を 4.9.2　に上げる
   - com.github.ben-manes:gradle-versions-plugin を 0.42.0 に上げる
-  - org.jlleitschuh.gradle:ktlint-gradle を 10.3.0 に上げる
 
 
 ## sora-andoroid-sdk-2022.2.0

--- a/build.gradle
+++ b/build.gradle
@@ -10,12 +10,12 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.4'
+        classpath 'com.android.tools.build:gradle:7.2.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
 
-        classpath "com.github.ben-manes:gradle-versions-plugin:0.41.0"
-        classpath "org.jlleitschuh.gradle:ktlint-gradle:10.2.1"
+        classpath "com.github.ben-manes:gradle-versions-plugin:0.42.0"
+        classpath "org.jlleitschuh.gradle:ktlint-gradle:10.3.0"
     }
 
     // デバッグ用: true に設定すると wss ではなく ws で接続できる

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Jan 20 16:14:02 JST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/build.gradle
+++ b/samples/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'org.jlleitschuh.gradle.ktlint'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     defaultConfig {
         applicationId "jp.shiguredo.sora.sample"
         targetSdkVersion 30
@@ -71,7 +71,7 @@ configurations {
 }
 
 ktlint {
-    version = "0.43.2"
+    version = "0.45.2"
     android = false
     outputToConsole = true
     reporters {
@@ -84,23 +84,23 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${kotlin_version}"
     implementation "org.jetbrains.kotlin:kotlin-reflect:${kotlin_version}"
 
-    implementation 'com.google.code.gson:gson:2.8.9'
+    implementation 'com.google.code.gson:gson:2.9.0'
 
-    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.appcompat:appcompat:1.4.2'
     implementation "androidx.cardview:cardview:1.0.0"
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
 
-    implementation 'com.google.android.material:material:1.3.0'
+    implementation 'com.google.android.material:material:1.6.1'
     implementation 'com.jaredrummler:material-spinner:1.3.1'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
-    implementation 'androidx.navigation:navigation-fragment-ktx:2.3.5'
-    implementation 'androidx.navigation:navigation-ui-ktx:2.3.5'
-    implementation 'androidx.compose.ui:ui:1.0.3'
-    implementation 'androidx.compose.material:material:1.0.3'
-    implementation "androidx.compose.material:material-icons-extended:1.0.3"
-    implementation 'androidx.activity:activity-compose:1.3.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'androidx.navigation:navigation-fragment-ktx:2.4.2'
+    implementation 'androidx.navigation:navigation-ui-ktx:2.4.2'
+    implementation 'androidx.compose.ui:ui:1.1.1'
+    implementation 'androidx.compose.material:material:1.1.1'
+    implementation "androidx.compose.material:material-icons-extended:1.1.1"
+    implementation 'androidx.activity:activity-compose:1.4.0'
 
-    ext.pd_version = '4.9.1'
+    ext.pd_version = '4.9.2'
     implementation "com.github.permissions-dispatcher:permissionsdispatcher:${pd_version}"
     kapt "com.github.permissions-dispatcher:permissionsdispatcher-processor:${pd_version}"
 

--- a/samples/src/main/AndroidManifest.xml
+++ b/samples/src/main/AndroidManifest.xml
@@ -33,7 +33,8 @@
         <activity
             android:name=".ui.MessagingActivity"
             android:exported="false" />
-        <activity android:name=".ui.MainActivity">
+        <activity android:name=".ui.MainActivity"
+            android:exported="true" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -43,27 +44,34 @@
         <activity
             android:name=".ui.VoiceChatRoomSetupActivity"
             android:configChanges="orientation|screenSize"
-            android:label="ボイスチャット" />
+            android:label="ボイスチャット"
+            android:exported="true" />
         <activity
             android:name=".ui.VideoChatRoomSetupActivity"
             android:configChanges="orientation|screenSize"
-            android:label="ビデオチャット" />
-        <activity
+            android:label="ビデオチャット"
+            android:exported="true" />
+
+    <activity
             android:name=".ui.SpotlightRoomSetupActivity"
             android:configChanges="orientation|screenSize"
-            android:label="スポットライト" />
+            android:label="スポットライト"
+            android:exported="true" />
         <activity
             android:name=".ui.ScreencastSetupActivity"
             android:configChanges="orientation|screenSize"
-            android:label="スクリーンキャスト" />
-        <activity
+            android:label="スクリーンキャスト"
+            android:exported="true" />
+    <activity
             android:name=".ui.EffectedVideoChatSetupActivity"
             android:configChanges="orientation|screenSize"
-            android:label="ビデオエフェクト" />
-        <activity
+            android:label="ビデオエフェクト"
+            android:exported="true" />
+    <activity
             android:name=".ui.SimulcastSetupActivity"
             android:configChanges="orientation|screenSize"
-            android:label="サイマルキャスト" />
+            android:label="サイマルキャスト"
+            android:exported="true" />
         <!--
             以下は実際にWebRTCを利用して動画/音声の通話を行うActivity
             セッション中にActivityが破壊されないように次のどちらかの設定を行う
@@ -75,7 +83,8 @@
         <activity
             android:name=".ui.VideoChatRoomActivity"
             android:configChanges="orientation|screenSize"
-            android:label="ビデオチャット">
+            android:label="ビデオチャット"
+            android:exported="true" >
 
             <!-- <intent-filter> -->
             <!-- <action android:name="android.intent.action.MAIN" /> -->
@@ -87,9 +96,10 @@
         <activity
             android:name=".ui.VoiceChatRoomActivity"
             android:configChanges="orientation|screenSize"
-            android:label="ボイスチャット" />
+            android:label="ボイスチャット"
+            android:exported="true" />
 
-        <service
+    <service
             android:name=".screencast.SoraScreencastService"
             android:configChanges="orientation|screenSize"
             android:enabled="true"
@@ -98,11 +108,13 @@
         <activity
             android:name=".ui.EffectedVideoChatActivity"
             android:configChanges="orientation|screenSize"
-            android:label="エフェクト付きビデオチャット" />
+            android:label="エフェクト付きビデオチャット"
+            android:exported="true" />
         <activity
             android:name=".ui.SimulcastActivity"
             android:configChanges="orientation|screenSize"
-            android:label="Simulcast" />
+            android:label="Simulcast"
+            android:exported="true" />
     </application>
 
 </manifest>


### PR DESCRIPTION
依存パッケージのアップデートを行っています。動作確認済みです。
また、アップデートに必要であったため、 compileSdkVersion 31 に上げる変更を行なっています。
クイックスタートやサンプルは SDK 本体ではないためアップデートしてよいと考えています。

特記事項

- Kotlin の  1.7.0 関連のアップデートは見送っています。影響未確認の部分があって慎重に作業をしたいため別にします。
- Android Studio のバージョンを 2021.2.1 にあげていただく必要があります
- AndroidManifest .xml の修正は compileSdkVersion 31 に上げるに伴い必要になりました
https://developer.android.com/about/versions/12/behavior-changes-12?hl=ja#exported