### PR TITLE
enableVideoDownstream に eglContext を設定する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,7 +35,10 @@
   - com.github.permissions-dispatcher:permissionsdispatcher を 4.9.2　に上げる
   - com.github.permissions-dispatcher:permissionsdispatcher-processor を 4.9.2　に上げる
   - com.github.ben-manes:gradle-versions-plugin を 0.42.0 に上げる
+  - @miosakuma
+
 - [FIX] メッセージングアプリが H.264 で接続中の別クライアントがいるときに接続エラーになる問題を修正する
+  - @miosakuma
 
 ## sora-andoroid-sdk-2022.2.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,7 @@
   - com.github.permissions-dispatcher:permissionsdispatcher を 4.9.2　に上げる
   - com.github.permissions-dispatcher:permissionsdispatcher-processor を 4.9.2　に上げる
   - com.github.ben-manes:gradle-versions-plugin を 0.42.0 に上げる
+- [FIX] メッセージングアプリが H.264 で接続中の別クライアントがいるときに接続エラーになる問題を修正する
 
 ## sora-andoroid-sdk-2022.2.0
 

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/MessagingActivity.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/MessagingActivity.kt
@@ -80,6 +80,7 @@ import jp.shiguredo.sora.sdk.channel.option.SoraMediaOption
 import jp.shiguredo.sora.sdk.error.SoraErrorReason
 import jp.shiguredo.sora.sdk.error.SoraMessagingError
 import jp.shiguredo.sora.sdk.util.SoraLogger
+import org.webrtc.EglBase
 import java.lang.Exception
 import java.nio.ByteBuffer
 import kotlin.random.Random
@@ -578,10 +579,11 @@ class SoraMessagingChannel {
         val signalingMetadata = Gson().fromJson(BuildConfig.SIGNALING_METADATA, Map::class.java)
 
         val mediaOption = SoraMediaOption()
-        mediaOption.role = SoraChannelRole.SENDRECV
+        val egl: EglBase? = EglBase.create()
+        mediaOption.role = SoraChannelRole.RECVONLY
         mediaOption.enableMultistream()
         // Sora 側で data_channel_messaging_only = true の場合、 enableVideoDownstream は不要
-        mediaOption.enableVideoDownstream(null)
+        mediaOption.enableVideoDownstream(egl!!.eglBaseContext)
 
         mediaChannel = SoraMediaChannel(
             context = context,

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/MessagingActivity.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/MessagingActivity.kt
@@ -582,7 +582,9 @@ class SoraMessagingChannel {
         val egl: EglBase? = EglBase.create()
         mediaOption.role = SoraChannelRole.RECVONLY
         mediaOption.enableMultistream()
-        // Sora 側で data_channel_messaging_only = true の場合、 enableVideoDownstream は不要
+        // 映像の送受信を行わず、メッセージング機能のみを利用する場合は  Sora 側で data_channel_messaging_only = true を設定する必要があります
+        // このサンプルでは Sora の設定に関わらず動作するように、不要な映像の受信 (enableVideoDownstream) を行なっています。
+        // Sora 側で data_channel_messaging_only = true を設定している場合、 この enableVideoDownstream は不要になります。
         mediaOption.enableVideoDownstream(egl!!.eglBaseContext)
 
         mediaChannel = SoraMediaChannel(


### PR DESCRIPTION
接続相手に sendrecv H.264 で接続しているクライアントがいるときにメッセージングアプリが接続エラーになる問題が発生していました。

`mediaOption.enableVideoDownstream()` に eglContext を設定することで事象が改善したので PR にしました。
最小限の修正をして、動いたからよし、としてしまっています。問題ないか確認をしていただけると助かります。。