### PR TITLE
CHANGES.md のインデントを 4 にそろえる

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,128 +12,128 @@
 ## develop
 
 - [UPDATE] `compileSdkVersion` を 32 に上げる
-  - @miosakuma
+    - @miosakuma
 - [UPDATE] `targetSdkVersion` を 32 に上げる
-  - @miosakuma
+    - @miosakuma
 - [UPDATE] Kotlin のバージョンを 1.7.10 に上げる
-  - @miosakuma
+    - @miosakuma
 - [UPDATE] Gradle を 7.5.1 に上げる
     - @miosakuma
 - [UPDATE] 依存ライブラリーのバージョンを上げる
-  - com.google.code.gson:gson を 2.9.1 に上げる
-  - androidx.appcompat:appcompat を 1.5.0 に上げる
-  - androidx.navigation:navigation-fragment-ktx を 2.5.1 に上げる
-  - androidx.navigation:navigation-ui-ktx を 2.5.1 に上げる
-  - androidx.compose.ui:ui:1.2.1 に上げる
-  - androidx.compose.material:material を 1.2.1 に上げる
-  - androidx.compose.material:material-icons-extended を 1.2.1 に上げる
-  - androidx.activity:activity-compose を 1.5.1 に上げる
-  - com.android.tools.build:gradle を 7.2.2 に上げる
-  - @miosakuma
+    - com.google.code.gson:gson を 2.9.1 に上げる
+    - androidx.appcompat:appcompat を 1.5.0 に上げる
+    - androidx.navigation:navigation-fragment-ktx を 2.5.1 に上げる
+    - androidx.navigation:navigation-ui-ktx を 2.5.1 に上げる
+    - androidx.compose.ui:ui:1.2.1 に上げる
+    - androidx.compose.material:material を 1.2.1 に上げる
+    - androidx.compose.material:material-icons-extended を 1.2.1 に上げる
+    - androidx.activity:activity-compose を 1.5.1 に上げる
+    - com.android.tools.build:gradle を 7.2.2 に上げる
+    - @miosakuma
 
 ## sora-andoroid-sdk-2022.3.0
 
 - [ADD] 解像度の調整を ON/OFF する UI を追加する
-  - @enm10k
+    - @enm10k
 - [ADD] プロキシを gradle.properties ファイルから設定できるようにする
-  - @enm10k
+    - @enm10k
 - [UPDATE] システム条件を更新する
-  - Android Studio 2021.2.1 以降
-  - WebRTC SFU Sora 2022.1.0 以降
-  - Sora Android SDK 2022.3.0 以降
-  - @miosakuma
+    - Android Studio 2021.2.1 以降
+    - WebRTC SFU Sora 2022.1.0 以降
+    - Sora Android SDK 2022.3.0 以降
+    - @miosakuma
 - [UPDATE] compileSdkVersion を 31 に上げる
-  - AndroidManifest.xml の Activity に `android:exported="true"` を明示的に記載する
-  - @miosakuma
+    - AndroidManifest.xml の Activity に `android:exported="true"` を明示的に記載する
+    - @miosakuma
 - [UPDATE] Gradle のバージョンを 7.4.2 に上げる
-  - @miosakuma
+    - @miosakuma
 - [UPDATE] Gktlint のバージョンを 0.45.2 に上げる
-  - @miosakuma
+    - @miosakuma
 - [UPDATE] 依存ライブラリを更新する
-  - com.android.tools.build:gradle を 7.2.1 に上げる
-  - org.jlleitschuh.gradle:ktlint-gradle を 10.3.0 に上げる
-  - com.google.code.gson:gson を 2.9.0 に上げる  
-  - androidx.appcompat:appcompat を 1.4.2 に上げる
-  - com.google.android.material:material を 1.6.1 に上げる
-  - androidx.constraintlayout:constraintlayout を 2.1.4 に上げる
-  - androidx.navigation:navigation-fragment-ktx を 2.4.2 に上げる
-  - androidx.navigation:navigation-ui-ktx を 2.4.2 に上げる
-  - androidx.compose.ui:ui:1.1.1 に上げる
-  - androidx.compose.material:material を 1.1.1 に上げる
-  - androidx.compose.material:material-icons-extended を 1.1.1 に上げる
-  - androidx.activity:activity-compose を 1.4.0 に上げる
-  - com.github.permissions-dispatcher:permissionsdispatcher を 4.9.2　に上げる
-  - com.github.permissions-dispatcher:permissionsdispatcher-processor を 4.9.2　に上げる
-  - com.github.ben-manes:gradle-versions-plugin を 0.42.0 に上げる
-  - @miosakuma
+    - com.android.tools.build:gradle を 7.2.1 に上げる
+    - org.jlleitschuh.gradle:ktlint-gradle を 10.3.0 に上げる
+    - com.google.code.gson:gson を 2.9.0 に上げる  
+    - androidx.appcompat:appcompat を 1.4.2 に上げる
+    - com.google.android.material:material を 1.6.1 に上げる
+    - androidx.constraintlayout:constraintlayout を 2.1.4 に上げる
+    - androidx.navigation:navigation-fragment-ktx を 2.4.2 に上げる
+    - androidx.navigation:navigation-ui-ktx を 2.4.2 に上げる
+    - androidx.compose.ui:ui:1.1.1 に上げる
+    - androidx.compose.material:material を 1.1.1 に上げる
+    - androidx.compose.material:material-icons-extended を 1.1.1 に上げる
+    - androidx.activity:activity-compose を 1.4.0 に上げる
+    - com.github.permissions-dispatcher:permissionsdispatcher を 4.9.2　に上げる
+    - com.github.permissions-dispatcher:permissionsdispatcher-processor を 4.9.2　に上げる
+    - com.github.ben-manes:gradle-versions-plugin を 0.42.0 に上げる
+    - @miosakuma
 - [FIX] メッセージングアプリが H.264 で接続中の別クライアントがいるときに接続エラーになる問題を修正する
-  - @miosakuma
+    - @miosakuma
 
 ## sora-andoroid-sdk-2022.2.0
 
 - [UPDATE] システム条件を更新する
-  - Android 8.0 以降
-  - Android Studio 2022.1.1 以降
-  - Sora Android SDK 2022.2.0 以降
-  - @miosakuma
+    - Android 8.0 以降
+    - Android Studio 2022.1.1 以降
+    - Sora Android SDK 2022.2.0 以降
+    - @miosakuma
 - [UPDATE] Kotlin synthetics の廃止に伴い View binding に移行する
-  - @miosakuma @enm10k
+    - @miosakuma @enm10k
 - [CHANGE] minSdkVersion を 26 に上げる
-  - @enm10k
+    - @enm10k
 
 ## sora-andoroid-sdk-2022.1.0
 
 - [UPDATE] システム条件を更新する
-  - Android Studio 2020.3.1 以降
-  - Sora Android SDK 2022.1.0 以降
-  - @miosakuma
+    - Android Studio 2020.3.1 以降
+    - Sora Android SDK 2022.1.0 以降
+    - @miosakuma
 - [ADD] シグナリング接続時に送信するメタデータを外部ファイルから設定できるようにする
-  - @miosakuma
+    - @miosakuma
 - [CHANGE] スポットライトレガシーを削除する
-  - @enm10k
+    - @enm10k
 - [CHANGE] シグナリングの URL指定を `signaling_endpoint` から `signalingEndpointCandidates` に変更する
-  - @miosakuma @enm10k
+    - @miosakuma @enm10k
 - [FIX] sendrecv 接続時に映像の送信を無効に設定し、かつ相手が H.264 の映像を送信するとき接続が失敗する不具合を修正する
-  - @miosakuma
+    - @miosakuma
 
 ## sora-android-sdk-2021.3
 
 - [UPDATE] システム条件を更新する
-  - Sora Android SDK 2021.3 以降
-  - @miosakuma
+    - Sora Android SDK 2021.3 以降
+    - @miosakuma
 
 ## sora-android-sdk-2021.2
 
 - [UPDATE] システム条件を更新する
-  - Android Studio 4.2 以降
-  - WebRTC SFU Sora 2021.1 以降
-  - Sora Android SDK 2021.2 以降
-  - @miosakuma
+    - Android Studio 4.2 以降
+    - WebRTC SFU Sora 2021.1 以降
+    - Sora Android SDK 2021.2 以降
+    - @miosakuma
 - [UPDATE] sdk が channel_id を必須にした変更に追従する
-  - @shino
+    - @shino
 - [UPDATE] spotlight_number は未指定をデフォルトにする
-  - @shino
+    - @shino
 - [UPDATE] `com.android.tools.build:gradle` を 4.2.2 に上げる
-  - @enm10k
+    - @enm10k
 - [UPDATE] JCenter への参照を取り除く
-  - @enm10k
+    - @enm10k
 - [UPDATE] シグナリングエンドポイント URL の設定を `/build.gradle` から `/gradle.properties.example` に移動する
-  - @miosakuma
+    - @miosakuma
 - [ADD] サイマルキャストの接続時に simulcast_rid を指定できるようにする
-  - @enm10k
+    - @enm10k
 - [ADD] スポットライトの接続時に spotlight_focus_rid / spotlight_unfocus_rid を指定できるようにする
-  - @enm10k
+    - @enm10k
 - [CHANGE] サイマルキャスト画面から、受信する rid を指定するボタンを削除する
-  - @enm10k
+    - @enm10k
 - [FIX] 自身の映像プレビューが反転している問題を修正する
-  - @torikizi
+    - @torikizi
 - [FIX] gradle.properties で指定した usesCleartextTraffic が参照されずに、常に true になっていた問題を修正する
-  - @enm10k
+    - @enm10k
 
 ## sora-android-sdk-2021.1.1
 
 - [UPDATE] SDK のバージョンを 2021.1.1 に上げる
-  - @enm10k
+    - @enm10k
 
 ## 2021.1
 
@@ -144,20 +144,20 @@
 - Kotlin を 1.4.31 に更新する
 - Gradle を 6.8.3 に更新する
 - 依存ライブラリを更新する
-  - com.github.ben-manes:gradle-versions-plugin を 0.38.0 に更新する
-  - com.android.tools.build:gradle を 4.1.2 に更新する
-  - com.google.android.material:material を 1.3.0 に更新する
-  - androidx.navigation:navigation-fragment-ktx を 2.3.3 に更新する
-  - androidx.navigation:navigation-ui-ktx を 2.3.3 に更新する
-  - jp.co.cyberagent.android:gpuimage を 2.1.0 に更新する
+    - com.github.ben-manes:gradle-versions-plugin を 0.38.0 に更新する
+    - com.android.tools.build:gradle を 4.1.2 に更新する
+    - com.google.android.material:material を 1.3.0 に更新する
+    - androidx.navigation:navigation-fragment-ktx を 2.3.3 に更新する
+    - androidx.navigation:navigation-ui-ktx を 2.3.3 に更新する
+    - jp.co.cyberagent.android:gpuimage を 2.1.0 に更新する
 
 ### ADD
 
 - サイマルキャスト画面を新規に追加する
 - データチャネルシグナリングに対応する
-  - ビデオチャット、ボイスチャット、サイマルキャスト、スポットライトが対象
-  - data_channel_signlaing, ignore_disconnect_websocket パラメータ設定を追加する
-  - @shino
+    - ビデオチャット、ボイスチャット、サイマルキャスト、スポットライトが対象
+    - data_channel_signlaing, ignore_disconnect_websocket パラメータ設定を追加する
+    - @shino
 
 ### CHANGE
 
@@ -172,8 +172,8 @@
 - ボイスチャット画面でマルチストリームが無効にできない問題を修正する
 - 音声のみを受信するよう設定したにも関わらず、映像を受信してしまう問題を修正する
 - スクリーンキャスト画面がクラッシュしていた問題を修正する
-  - Android 10 からは、特定のサービスを定義する際に、マニフェストに foregroundServiceType を定義する必要がある
-  - 参考: https://developer.android.com/about/versions/10/features?hl=ja#fg-service-types
+    - Android 10 からは、特定のサービスを定義する際に、マニフェストに foregroundServiceType を定義する必要がある
+    - 参考: <https://developer.android.com/about/versions/10/features?hl=ja#fg-service-types>
 - ビデオチャット画面の起動時に縦固定となる問題を修正する
 - 各画面で端末回転に追随しない問題を修正する
 
@@ -192,10 +192,10 @@
 ### ADD
 
 - video chat room にステレオで配信するオプションを追加する
-  - Andoird 9 / Pixel3 XL からの配信で動作を確認している
-    - カメラを体の前に持った状態で、液晶を自分向き、ホームボタン側を自分から見て右にした状態
-    - 映像はリアカメラからの入力
-    - マイクは内蔵を利用し、上部が左、下部を右とすると映像の向きとステレオの左右が同期する
+    - Andoird 9 / Pixel3 XL からの配信で動作を確認している
+        - カメラを体の前に持った状態で、液晶を自分向き、ホームボタン側を自分から見て右にした状態
+        - 映像はリアカメラからの入力
+        - マイクは内蔵を利用し、上部が左、下部を右とすると映像の向きとステレオの左右が同期する
 
 ### CHANGE
 
@@ -240,7 +240,7 @@
 - Video chat に client ID を指定する選択肢を追加する
 - Video chat に解像度固定の選択肢を追加する
 - Video chat のビットレートに 10Mbps, 15Mbps, 20Mbps, 30Mbps を追加する
-  - 15Mbps までが Sora のサポート範囲
+    - 15Mbps までが Sora のサポート範囲
 - Video chat に signalingNotifyMetadata を追加する
 
 ## 1.8.0
@@ -261,18 +261,18 @@
 ### CHANGE
 
 - SDP semantics の選択肢のデフォルト値を Unified Plan に変更する
-  - upstream のシグナリングで audio や video が false の場合でも、他の配信者の
+    - upstream のシグナリングで audio や video が false の場合でも、他の配信者の
     audio や video のトラックを受信する SDP が Sora から offer されるように変わる
-  - Plan B のときには audio false のときには audio track が SDP に含まれず、
+    - Plan B のときには audio false のときには audio track が SDP に含まれず、
     video が false のときには video のトラックが含まれなかった
-    - Plan B の制限による挙動だった
+        - Plan B の制限による挙動だった
 
 ### ADD
 
 - Effected video chat にセピアトーン化のエフェクトを追加する
-  - Thanks to @daneko
+    - Thanks to @daneko
 - Effected video chat にデバッグ、比較用としてなにもしないエフェクトを追加する
-  - Thanks to @daneko
+    - Thanks to @daneko
 
 ### CHANGE
 
@@ -281,16 +281,16 @@
 ### FIX
 
 - Effected video chat で I420 から変換された RGB データがずれていた問題を修正する
-  - これに伴い、NV12/NV21 の経由を廃止し、I420 と RGBA の直接の相互変換する
-  - Thanks to @daneko
+    - これに伴い、NV12/NV21 の経由を廃止し、I420 と RGBA の直接の相互変換する
+    - Thanks to @daneko
 
 ## 1.7.1
 
 ### ADD
 
 - Video chat, Voice chat, Spotlight の各セットアップに sdpSemantics 選択肢を追加する
-  - ただし、Sora Android SDK の動作確認は Plan B のみで Unified Plan は試験的実装
-  - Voice chat は Unified Plan 選択時にエラーで接続できない
+    - ただし、Sora Android SDK の動作確認は Plan B のみで Unified Plan は試験的実装
+    - Voice chat は Unified Plan 選択時にエラーで接続できない
 
 ### UPDATE
 
@@ -316,16 +316,16 @@
 - SDK のバージョンを 1.6.0 に上げる
 - Android Studio 3.1.3 に対応する
 - PermissionsDispatcher を 3.2.0 に上げる
-  - lint バグフィックスにより不要な SuppressLint アノテーションを削除する
+    - lint バグフィックスにより不要な SuppressLint アノテーションを削除する
 - Kotlin を 1.2.51 に上げる
 - START ボタンをオプションリストの上に移動する
 - CircleCI キャッシュを利用しない
-  - ときどきビルドが失敗するが、キャッシュ利用しないと成功するため
-  - NDK セットアップに 37 sec, androidDependencies に 43 sec 程度
-  - ただしキャッシュがビルド失敗の根本原因かは不明
+    - ときどきビルドが失敗するが、キャッシュ利用しないと成功するため
+    - NDK セットアップに 37 sec, androidDependencies に 43 sec 程度
+    - ただしキャッシュがビルド失敗の根本原因かは不明
 - Anko を 0.10.5 に上げる
 - スクリーンキャスト画面を `TYPE_APPLICATION_OVERLAY` に変更する
-  - `TYPE_PHONE` が deprecated になったため
+    - `TYPE_PHONE` が deprecated になったため
 - Android 8 の Notification Channel に対応する
 - Video chat, Voice chat, Spotlight chat, effected video chat の音量を
   ボリュームキーから制御できるようにする
@@ -337,8 +337,8 @@
 ### ADD
 
 - スポットライト機能のデモを追加する
-  - 通信の方向は BIDIRECTIONAL(upstream) と MULTI_DOWN(downstream) を選択可能
-  - メディアは映像+音声か音声のみを選択可能
+    - 通信の方向は BIDIRECTIONAL(upstream) と MULTI_DOWN(downstream) を選択可能
+    - メディアは映像+音声か音声のみを選択可能
 
 ### CHANGE
 
@@ -359,7 +359,7 @@
 ### CHANGE
 
 - onByteBufferFrameCaptured が onFrameCaptured が置き換えられた変更に対応する
-  - cf. https://webrtc-review.googlesource.com/c/src/+/43022
+    - cf. <https://webrtc-review.googlesource.com/c/src/+/43022>
 
 - audio disabled のときは upstream/downstream ともに音声は無効にする
 - SoreRemoteRendererSlot の誤植を修正する
@@ -411,8 +411,8 @@
 
 - SDK のバージョンを 1.4.0 に上げる
 - Android Studio 3.0 に対応する
-  - gradle: 4.1
-  - android-maven-gradle-plugin: 2.0
+    - gradle: 4.1
+    - android-maven-gradle-plugin: 2.0
 - Kotlin 1.2.10 に上げる
 
 ## 1.3.1


### PR DESCRIPTION
CHANGE.md のフォーマット修正です。インデント 2 と 4 が混在していたので 4 に統一しています。
markdownlint のクイックフィックスを利用しており、リンク URL を `<>` で囲む修正も入っています。囲むことが正しいためクイックフィックスの結果を採用しています。