### PR TITLE
スポットライトサンプルの初期値を FHD,  映像bitrate を 5000 にする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,10 @@
     - androidx.activity:activity-compose を 1.5.1 に上げる
     - com.android.tools.build:gradle を 7.2.2 に上げる
     - @miosakuma
+- [UPDATE] スポットライト設定画面の初期値を変更する
+    - 映像サイズ VGA を FHD に変更
+    - 映像ビットレート 500 を 5000 に変更
+    - @miosakuma
 
 ## sora-andoroid-sdk-2022.3.0
 

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/SpotlightRoomSetupActivity.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/SpotlightRoomSetupActivity.kt
@@ -87,6 +87,9 @@ class SpotlightRoomSetupActivity : AppCompatActivity() {
         binding.dataChannelSignalingSelection.spinner.setItems(dataChannelSignalingOptions)
         binding.ignoreDisconnectWebSocketSelection.name.text = "WS 切断を無視"
         binding.ignoreDisconnectWebSocketSelection.spinner.setItems(ignoreDisconnectWebSocketOptions)
+
+        binding.videoBitRateSelection.spinner.selectedIndex = 6
+        binding.videoSizeSelection.spinner.selectedIndex = 5
     }
 
     private fun startSpotlightChat() {


### PR DESCRIPTION
スポットライトサンプルの設定画面初期値を以下のように変更します。サイマルキャスト時に 3 本の映像が出るようにしたいためです。
サイマルキャストサンプルの初期値と同じ設定にしています。

映像サイズ: VGA -> FHD
映像ビットレート: 500 -> 5000