### PR TITLE
サンプルに AV1 を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,8 @@
     - androidx.activity:activity-compose を 1.5.1 に上げる
     - com.android.tools.build:gradle を 7.2.2 に上げる
     - @miosakuma
+- [UPDATE] ビデオチャットとスクリーンキャストの映像コーデックに AV1 を追加する
+    - @miosakuma
 
 ## sora-andoroid-sdk-2022.3.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@
     - Android Studio 2022.1.1 以降
     - WebRTC SFU Sora 2022.2.0 以降
     - @miosakuma
+- [ADD] 映像コーデックに AV1 を追加する
+    - @miosakuma
 - [ADD] ビデオチャットサンプルに音声ストリーミング機能の言語コードを追加する
     - @miosakuma
 
@@ -38,8 +40,6 @@
     - androidx.compose.material:material-icons-extended を 1.2.1 に上げる
     - androidx.activity:activity-compose を 1.5.1 に上げる
     - com.android.tools.build:gradle を 7.2.2 に上げる
-    - @miosakuma
-- [UPDATE] ビデオチャットとスクリーンキャストの映像コーデックに AV1 を追加する
     - @miosakuma
 
 ## sora-andoroid-sdk-2022.3.0

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/ScreencastSetupActivity.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/ScreencastSetupActivity.kt
@@ -21,7 +21,7 @@ class ScreencastSetupActivity : AppCompatActivity() {
         val TAG = ScreencastSetupActivity::class.simpleName
     }
 
-    private val videoCodecOptions = listOf("VP9", "VP8", "H264")
+    private val videoCodecOptions = listOf("VP9", "VP8", "H264", "AV1")
     private val audioCodecOptions = listOf("OPUS")
     private val multistreamOptions = listOf("有効", "無効")
 

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/SpotlightRoomSetupActivity.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/SpotlightRoomSetupActivity.kt
@@ -16,7 +16,7 @@ class SpotlightRoomSetupActivity : AppCompatActivity() {
     }
 
     private val spotlightNumberOptions = listOf("未指定", "1", "2", "3", "4", "5", "6", "7", "8")
-    private val videoCodecOptions = listOf("VP8", "VP9", "H264")
+    private val videoCodecOptions = listOf("VP8", "VP9", "H264", "AV1")
     private val audioCodecOptions = listOf("OPUS")
     private val audioBitRateOptions = listOf(
         "未指定", "8", "16", "24", "32",

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/VideoChatRoomSetupActivity.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/VideoChatRoomSetupActivity.kt
@@ -15,7 +15,7 @@ class VideoChatRoomSetupActivity : AppCompatActivity() {
         val TAG = VideoChatRoomSetupActivity::class.simpleName
     }
 
-    private val videoCodecOptions = listOf("VP9", "VP8", "H264")
+    private val videoCodecOptions = listOf("VP9", "VP8", "H264", "AV1")
     private val videoEnabledOptions = listOf("有効", "無効")
     private val audioCodecOptions = listOf("OPUS")
     private val audioEnabledOptions = listOf("有効", "無効")


### PR DESCRIPTION
サンプルの映像コーデックに AV1 を追加しました。
追加したサンプルはコミットログより確認ください。

スポットライトサンプルもサイマルキャストを無効にすれば AV1 が利用可能であるため追加しています。（サイマルキャスト を選択すると Sora 側でエラーとなりアプリが終了します）

Sora 側のエラーがアプリに表示されない問題についてはまた別途対応したいと思います。