### PR TITLE
依存ライブラリのバージョンアップとそれに付随する対応

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
+  <component name="GradleSettings">
+    <option name="linkedExternalProjectsSettings">
+      <GradleProjectSettings>
+        <option name="testRunner" value="GRADLE" />
+        <option name="distributionType" value="DEFAULT_WRAPPED" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleHome" value="$USER_HOME$/development/gradle-7.5.1" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$" />
+            <option value="$PROJECT_DIR$/samples" />
+            <option value="$PROJECT_DIR$/webrtc-video-effector" />
+          </set>
+        </option>
+      </GradleProjectSettings>
+    </option>
+  </component>
+</project>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@
 - [UPDATE] Compose Compiler のバージョンを 1.4.3 に上げる
     - @miosakuma
 - [UPDATE] 依存ライブラリーのバージョンを上げる
+    - com.android.tools.build:gradle を 7.4.2 に上げる
     - com.github.ben-manes:gradle-versions-plugin を 0.46.0 に上げる
     - org.jlleitschuh.gradle:ktlint-gradle を 11.3.1 に上げる
     - com.google.code.gson:gson を 2.10.1 に上げる

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,28 @@
     - Android Studio 2022.1.1 以降
     - WebRTC SFU Sora 2022.2.0 以降
     - @miosakuma
+- [UPDATE] `compileSdkVersion` を 33 に上げる
+    - @miosakuma
+- [UPDATE] `targetSdkVersion` を 33 に上げる
+    - @miosakuma
+- [UPDATE] Kotlin のバージョンを 1.8.10 に上げる
+    - @miosakuma
+- [UPDATE] Compose Compiler のバージョンを 1.4.3 に上げる
+    - @miosakuma
+- [UPDATE] 依存ライブラリーのバージョンを上げる
+    - com.github.ben-manes:gradle-versions-plugin を 0.46.0 に上げる
+    - org.jlleitschuh.gradle:ktlint-gradle を 11.3.1 に上げる
+    - com.google.code.gson:gson を 2.10.1 に上げる
+    - androidx.appcompat:appcompat を 1.6.1 に上げる
+    - androidx.recyclerview:recyclerview: を 1.3.0 に上げる
+    - com.google.android.material:material: を 1.8.0 に上げる
+    - androidx.navigation:navigation-fragment-ktx を 2.5.3 に上げる
+    - androidx.navigation:navigation-ui-ktx を 2.5.3 に上げる
+    - androidx.compose.ui:ui:1.4.0 に上げる
+    - androidx.compose.material:material を 1.4.0 に上げる
+    - androidx.compose.material:material-icons-extended を 1.4.0 に上げる
+    - androidx.activity:activity-compose を 1.7.0 に上げる
+
 - [ADD] 映像コーデックに AV1 を追加する
     - @miosakuma
 - [ADD] ビデオチャットサンプルに音声ストリーミング機能の言語コードを追加する

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,8 @@
     - @miosakuma
 - [UPDATE] Compose Compiler のバージョンを 1.4.3 に上げる
     - @miosakuma
+- [UPDATE] Gradle を 7.6.1 に上げる
+    - @miosakuma
 - [UPDATE] 依存ライブラリーのバージョンを上げる
     - com.android.tools.build:gradle を 7.4.2 に上げる
     - com.github.ben-manes:gradle-versions-plugin を 0.46.0 に上げる

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.2'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: "com.github.ben-manes.versions"
 
 buildscript {
-    ext.kotlin_version = '1.7.10'
+    ext.kotlin_version = '1.8.10'
     ext.sora_android_sdk_version = 'develop-SNAPSHOT'
 
     repositories {
@@ -14,8 +14,8 @@ buildscript {
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
 
-        classpath "com.github.ben-manes:gradle-versions-plugin:0.42.0"
-        classpath "org.jlleitschuh.gradle:ktlint-gradle:10.3.0"
+        classpath "com.github.ben-manes:gradle-versions-plugin:0.46.0"
+        classpath "org.jlleitschuh.gradle:ktlint-gradle:11.3.1"
     }
 
     // デバッグ用: true に設定すると wss ではなく ws で接続できる

--- a/samples/build.gradle
+++ b/samples/build.gradle
@@ -4,10 +4,10 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'org.jlleitschuh.gradle.ktlint'
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 33
     defaultConfig {
         applicationId "jp.shiguredo.sora.sample"
-        targetSdkVersion 30
+        targetSdkVersion 33
         minSdkVersion 26
         versionCode 1
         versionName "1.0"
@@ -49,7 +49,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion '1.3.0'
+        kotlinCompilerExtensionVersion '1.4.3'
     }
 
     buildTypes {
@@ -91,21 +91,21 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${kotlin_version}"
     implementation "org.jetbrains.kotlin:kotlin-reflect:${kotlin_version}"
 
-    implementation 'com.google.code.gson:gson:2.9.1'
+    implementation 'com.google.code.gson:gson:2.10.1'
 
-    implementation 'androidx.appcompat:appcompat:1.5.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation "androidx.cardview:cardview:1.0.0"
-    implementation 'androidx.recyclerview:recyclerview:1.2.1'
+    implementation 'androidx.recyclerview:recyclerview:1.3.0'
 
-    implementation 'com.google.android.material:material:1.6.1'
+    implementation 'com.google.android.material:material:1.8.0'
     implementation 'com.jaredrummler:material-spinner:1.3.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation 'androidx.navigation:navigation-fragment-ktx:2.5.1'
-    implementation 'androidx.navigation:navigation-ui-ktx:2.5.1'
-    implementation 'androidx.compose.ui:ui:1.2.1'
-    implementation 'androidx.compose.material:material:1.2.1'
-    implementation "androidx.compose.material:material-icons-extended:1.2.1"
-    implementation 'androidx.activity:activity-compose:1.5.1'
+    implementation 'androidx.navigation:navigation-fragment-ktx:2.5.3'
+    implementation 'androidx.navigation:navigation-ui-ktx:2.5.3'
+    implementation 'androidx.compose.ui:ui:1.4.0'
+    implementation 'androidx.compose.material:material:1.4.0'
+    implementation "androidx.compose.material:material-icons-extended:1.4.0"
+    implementation 'androidx.activity:activity-compose:1.7.0'
 
     ext.pd_version = '4.9.2'
     implementation "com.github.permissions-dispatcher:permissionsdispatcher:${pd_version}"

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/screencast/SoraScreencastService.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/screencast/SoraScreencastService.kt
@@ -104,7 +104,7 @@ class SoraScreencastService : Service() {
             }
 
         val activityIntent = createBoundActivityIntent()
-        val pendingIntent = PendingIntent.getActivity(this, 0, activityIntent, 0)
+        val pendingIntent = PendingIntent.getActivity(this, 0, activityIntent, PendingIntent.FLAG_MUTABLE)
         val notification = NotificationCompat.Builder(this, notificationChannelId)
             .setContentTitle(req!!.stateTitle)
             .setContentText(req!!.stateText)

--- a/webrtc-video-effector/build.gradle
+++ b/webrtc-video-effector/build.gradle
@@ -2,9 +2,9 @@ apply plugin: 'com.android.library'
 apply plugin: 'org.jlleitschuh.gradle.ktlint'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
     defaultConfig {
-        targetSdkVersion 30
+        targetSdkVersion 33
         minSdkVersion 26
         externalNativeBuild {
             cmake {


### PR DESCRIPTION
sora-android-sdk のライブラリのバージョンアップに合わせてサンプルについてもバージョンアップを実施しました。

最新のバージョンが利用できるように targetSdkVersion のバージョンをあげています。
それに伴い、Target SDK 31 から設定が必須となった PendingIntent. getActivities の flag の設定を追加しています。(b16bbd5930af5edc14f51442a019c5446bd2b6d9)
`PendingIntent.FLAG_MUTABLE` を設定していますが、これはデフォルトの動きを踏襲する設定です。