### PR TITLE
サイマルキャストの映像コーデックにVP9とAV1を追加する

### DIFF
--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/SimulcastSetupActivity.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/SimulcastSetupActivity.kt
@@ -15,7 +15,7 @@ class SimulcastSetupActivity : AppCompatActivity() {
         val TAG = SimulcastSetupActivity::class.simpleName
     }
 
-    private val videoCodecOptions = listOf("VP8", "H264")
+    private val videoCodecOptions = listOf("VP8", "VP9", "H264", "AV1")
     private val videoEnabledOptions = listOf("有効", "無効")
     private val audioCodecOptions = listOf("OPUS")
     private val audioEnabledOptions = listOf("有効", "無効")


### PR DESCRIPTION
サイマルキャストのテスト画面にて、選択可能な映像コーデックに VP9 と AV1 を追加します。

本 PR は Sora Android SDK が VP9 と AV1 のサイマルキャストに対応するためのコードではありません。 VP9 と AV1 のサイマルキャストの対応は Sora Android SDK のアップデートを待つ必要があります。