### PR TITLE
ビデオチャットにサンプルに映像コーデックのプロファイルを追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 ## develop
 
+- [ADD] ビデオチャットにサンプルに映像コーデックのプロファイルを追加する
+    - @miosakuma
+
 ## sora-andoroid-sdk-2023.1.0
 
 - [UPDATE] システム条件を更新する

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/facade/SoraVideoChannel.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/facade/SoraVideoChannel.kt
@@ -52,6 +52,9 @@ class SoraVideoChannel(
     private var videoEnabled: Boolean = true,
     private val videoWidth: Int = SoraVideoOption.FrameSize.Portrait.VGA.x,
     private val videoHeight: Int = SoraVideoOption.FrameSize.Portrait.VGA.y,
+    private val videoVp9Params: Any? = null,
+    private val videoAv1Params: Any? = null,
+    private val videoH264Params: Any? = null,
     private val simulcast: Boolean = false,
     private val simulcastRid: SoraVideoOption.SimulcastRid? = null,
     private val videoFPS: Int = 30,
@@ -276,6 +279,9 @@ class SoraVideoChannel(
 
             videoCodec = this@SoraVideoChannel.videoCodec
             videoBitrate = this@SoraVideoChannel.videoBitRate
+            videoVp9Params = this@SoraVideoChannel.videoVp9Params
+            videoAv1Params = this@SoraVideoChannel.videoAv1Params
+            videoH264Params = this@SoraVideoChannel.videoH264Params
 
             audioCodec = this@SoraVideoChannel.audioCodec
             audioBitrate = this@SoraVideoChannel.audioBitRate

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/VideoChatRoomActivity.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/VideoChatRoomActivity.kt
@@ -50,6 +50,9 @@ class VideoChatRoomActivity : AppCompatActivity() {
     private var videoBitRate: Int? = null
     private var videoWidth: Int = SoraVideoOption.FrameSize.Portrait.VGA.x
     private var videoHeight: Int = SoraVideoOption.FrameSize.Portrait.VGA.y
+    private var videoVp9Params: Any? = null
+    private var videoAv1Params: Any? = null
+    private var videoH264Params: Any? = null
     private var multistream = true
     private var spotlight = false
     private var spotlightNumber: Int? = null
@@ -136,6 +139,26 @@ class VideoChatRoomActivity : AppCompatActivity() {
             else -> false
         }
 
+        videoVp9Params = when (val stringValue = intent.getStringExtra("VP9_PROFILE_ID")) {
+            "未指定" -> null
+            else -> object {
+                var profile_id: Int? = stringValue?.toIntOrNull()
+            }
+        }
+
+        videoAv1Params = when (val stringValue = intent.getStringExtra("AV1_PROFILE")) {
+            "未指定" -> null
+            else -> object {
+                var profile: Int? = stringValue?.toIntOrNull()
+            }
+        }
+
+        videoH264Params = when (val stringValue = intent.getStringExtra("H264_PROFILE_LEVEL_ID")) {
+            "未指定" -> null
+            else -> object {
+                var profile_level_id: String? = stringValue
+            }
+        }
         resolutionAdjustment = when (intent.getStringExtra("RESOLUTION_ADJUSTMENT")) {
             "16" -> SoraVideoOption.ResolutionAdjustment.MULTIPLE_OF_16
             "8" -> SoraVideoOption.ResolutionAdjustment.MULTIPLE_OF_8
@@ -325,6 +348,9 @@ class VideoChatRoomActivity : AppCompatActivity() {
             videoWidth = videoWidth,
             videoHeight = videoHeight,
             videoFPS = fps,
+            videoVp9Params = videoVp9Params,
+            videoAv1Params = videoAv1Params,
+            videoH264Params = videoH264Params,
             fixedResolution = fixedResolution,
             resolutionAdjustment = resolutionAdjustment,
             videoCodec = videoCodec,

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/VideoChatRoomSetupActivity.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/VideoChatRoomSetupActivity.kt
@@ -31,6 +31,9 @@ class VideoChatRoomSetupActivity : AppCompatActivity() {
         "2000", "2500", "3000", "5000", "10000", "15000", "20000", "30000"
     )
     private val videoSizeOptions = SoraFrameSize.all.keys.toList()
+    private val vp9ProfileIdOptions = listOf("未指定", "0", "1", "2", "3")
+    private val av1ProfileOptions = listOf("未指定", "0", "1", "2")
+    private val h264ProfileLevelIdOptions = listOf("未指定", "42e01f", "42e020", "42e034")
     private val fpsOptions = listOf("30", "10", "15", "20", "24", "60")
     private val resolutionChangeOptions = listOf("可変", "固定")
     private val resolutionAdjustmentOptions = listOf("未指定", "16", "8", "4", "2", "無効")
@@ -73,6 +76,12 @@ class VideoChatRoomSetupActivity : AppCompatActivity() {
         binding.videoSizeSelection.name.text = "映像サイズ"
         binding.videoSizeSelection.spinner.setItems(videoSizeOptions)
         binding.videoSizeSelection.spinner.selectedIndex = 3
+        binding.vp9ProfileIdSelection.name.text = "VP9 プロファイル"
+        binding.vp9ProfileIdSelection.spinner.setItems(vp9ProfileIdOptions)
+        binding.av1ProfileSelection.name.text = "AV1 プロファイル"
+        binding.av1ProfileSelection.spinner.setItems(av1ProfileOptions)
+        binding.h264ProfileLevelIdSelection.name.text = "H264 プロファイル"
+        binding.h264ProfileLevelIdSelection.spinner.setItems(h264ProfileLevelIdOptions)
         binding.fpsSelection.name.text = "フレームレート"
         binding.fpsSelection.spinner.setItems(fpsOptions)
         binding.resolutionChangeSelection.name.text = "解像度の変更"
@@ -110,6 +119,9 @@ class VideoChatRoomSetupActivity : AppCompatActivity() {
         val audioStereo = selectedItem(binding.audioStereoSelection.spinner)
         val videoBitRate = selectedItem(binding.videoBitRateSelection.spinner)
         val videoSize = selectedItem(binding.videoSizeSelection.spinner)
+        val vp9ProfileId = selectedItem(binding.vp9ProfileIdSelection.spinner)
+        val av1Profile = selectedItem(binding.av1ProfileSelection.spinner)
+        val h264ProfileLevelId = selectedItem(binding.h264ProfileLevelIdSelection.spinner)
         val fps = selectedItem(binding.fpsSelection.spinner)
         val resolutionChange = selectedItem(binding.resolutionChangeSelection.spinner)
         val resolutionAdjustment = selectedItem(binding.resolutionAdjustmentSelection.spinner)
@@ -132,6 +144,9 @@ class VideoChatRoomSetupActivity : AppCompatActivity() {
         intent.putExtra("AUDIO_STEREO", audioStereo)
         intent.putExtra("VIDEO_BIT_RATE", videoBitRate)
         intent.putExtra("VIDEO_SIZE", videoSize)
+        intent.putExtra("VP9_PROFILE_ID", vp9ProfileId)
+        intent.putExtra("AV1_PROFILE", av1Profile)
+        intent.putExtra("H264_PROFILE_LEVEL_ID", h264ProfileLevelId)
         intent.putExtra("FPS", fps)
         intent.putExtra("RESOLUTION_CHANGE", resolutionChange)
         intent.putExtra("RESOLUTION_ADJUSTMENT", resolutionAdjustment)

--- a/samples/src/main/res/layout/activity_video_chat_room_setup.xml
+++ b/samples/src/main/res/layout/activity_video_chat_room_setup.xml
@@ -66,6 +66,15 @@
                     android:id="@+id/videoSizeSelection"/>
                 <include
                     layout="@layout/signaling_selection"
+                    android:id="@+id/vp9ProfileIdSelection"/>
+                <include
+                    layout="@layout/signaling_selection"
+                    android:id="@+id/av1ProfileSelection"/>
+                <include
+                    layout="@layout/signaling_selection"
+                    android:id="@+id/h264ProfileLevelIdSelection"/>
+                <include
+                    layout="@layout/signaling_selection"
                     android:id="@+id/resolutionChangeSelection"/>
                 <include
                     layout="@layout/signaling_selection"


### PR DESCRIPTION
ビデオチャットサンプルに映像コーデックのプロファイルを追加しました

- 映像関連の箇所がよいかと思い映像サイズの下に追加しました
- 他の項目とあわせてコンボボックス指定にしました

動作確認をして問題なさそうです。項目名や設定箇所等、もしご意見等ありましたらお願いします。