### PR TITLE
マルチウィンドウモード時に画面を回転すると Activity が再作成されるのを防ぐ設定を入れる

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 ## develop
 
+- [FIX] マルチウィンドウモード時に画面を回転すると Activity が再作成されるのを防ぐ設定を入れる
+    - @miosakuma
+
 ## sora-andoroid-sdk-2023.2.0
 
 - [UPDATE] システム条件を更新する

--- a/samples/src/main/AndroidManifest.xml
+++ b/samples/src/main/AndroidManifest.xml
@@ -43,33 +43,33 @@
         </activity>
         <activity
             android:name=".ui.VoiceChatRoomSetupActivity"
-            android:configChanges="orientation|screenSize"
+            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout"
             android:label="ボイスチャット"
             android:exported="true" />
         <activity
             android:name=".ui.VideoChatRoomSetupActivity"
-            android:configChanges="orientation|screenSize"
+            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout"
             android:label="ビデオチャット"
             android:exported="true" />
 
     <activity
             android:name=".ui.SpotlightRoomSetupActivity"
-            android:configChanges="orientation|screenSize"
+            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout"
             android:label="スポットライト"
             android:exported="true" />
         <activity
             android:name=".ui.ScreencastSetupActivity"
-            android:configChanges="orientation|screenSize"
+            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout"
             android:label="スクリーンキャスト"
             android:exported="true" />
     <activity
             android:name=".ui.EffectedVideoChatSetupActivity"
-            android:configChanges="orientation|screenSize"
+            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout"
             android:label="ビデオエフェクト"
             android:exported="true" />
     <activity
             android:name=".ui.SimulcastSetupActivity"
-            android:configChanges="orientation|screenSize"
+            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout"
             android:label="サイマルキャスト"
             android:exported="true" />
         <!--
@@ -77,12 +77,12 @@
             セッション中にActivityが破壊されないように次のどちらかの設定を行う
 
             1) android:screenOrientationを指定して向きを固定する
-            2) android:configChanges="orientation|screenSize"を指定しつつ
+            2) android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout"を指定しつつ
                ActivityのonConfigurationChangedメソッドでレイアウトを調整
         -->
         <activity
             android:name=".ui.VideoChatRoomActivity"
-            android:configChanges="orientation|screenSize"
+            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout"
             android:label="ビデオチャット"
             android:exported="true" >
 
@@ -95,24 +95,24 @@
         </activity>
         <activity
             android:name=".ui.VoiceChatRoomActivity"
-            android:configChanges="orientation|screenSize"
+            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout"
             android:label="ボイスチャット"
             android:exported="true" />
 
     <service
             android:name=".screencast.SoraScreencastService"
-            android:configChanges="orientation|screenSize"
+            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout"
             android:enabled="true"
             android:foregroundServiceType="mediaProjection" />
 
         <activity
             android:name=".ui.EffectedVideoChatActivity"
-            android:configChanges="orientation|screenSize"
+            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout"
             android:label="エフェクト付きビデオチャット"
             android:exported="true" />
         <activity
             android:name=".ui.SimulcastActivity"
-            android:configChanges="orientation|screenSize"
+            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout"
             android:label="Simulcast"
             android:exported="true" />
     </application>


### PR DESCRIPTION
Android の Tablet で映像送信中に画面を回転させると Activity の再作成が走ってしまう問題についての対応です。
設定画面を含めて同一の対応をしています。