### PR TITLE
Android Gradle Plugin を 8.5.0 にアップグレード

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,16 @@
 
 ## develop
 
+- [UPDATE] Android Gradle Plugin (AGP) を 8.5.0 にアップグレードする
+  - Android Studion の AGP Upgrade Assistant を利用してアップグレードされた内容
+    - `com.android.tools.build:gradle` を 8.5.0 に上げる
+    - ビルドに利用される Gradle を 8.7 に上げる
+    - Android マニフェストからビルドファイルにパッケージを移動
+      - Android マニフェストに定義されていた package を削除
+      - ビルドファイルに namespace を追加
+    - ビルドファイルの dependencies の transitive をコメントアウト
+  - @zztkm
+
 ## sora-andoroid-sdk-2024.2.0
 
 - [UPDATE] システム条件を更新する

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,8 @@
       - Android マニフェストに定義されていた package を削除
       - ビルドファイルに namespace を追加
     - ビルドファイルの dependencies の transitive をコメントアウト
+  - AGP 8.5.0 対応で発生したビルドスクリプトのエラーを手動で修正した内容
+    - AGP 8.0 から buildConfig がデフォルト false になったため、true に設定する
   - @zztkm
 
 ## sora-andoroid-sdk-2024.2.0

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.5.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Jan 20 16:14:02 JST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/build.gradle
+++ b/samples/build.gradle
@@ -46,6 +46,12 @@ android {
 
     buildFeatures {
         compose true
+
+        // AGP 8.0 からデフォルトで false になった
+        // このオプションが true でないと、defaultConfig に含まれている
+        // buildConfigField オプションが無効になってしまうため、true に設定する
+        // 参考: https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes#default-changes
+        buildConfig true
     }
 
     composeOptions {

--- a/samples/build.gradle
+++ b/samples/build.gradle
@@ -69,6 +69,8 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+    // AGP 8.0 からモジュールレベルの build script 内に namespace が必要になった
+    // 参考: https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes#namespace-dsl
     namespace 'jp.shiguredo.sora.sample'
 }
 

--- a/samples/build.gradle
+++ b/samples/build.gradle
@@ -69,6 +69,7 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+    namespace 'jp.shiguredo.sora.sample'
 }
 
 configurations {

--- a/samples/src/main/AndroidManifest.xml
+++ b/samples/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="jp.shiguredo.sora.sample">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-sdk tools:overrideLibrary="android.support.v17.leanback" />
 

--- a/webrtc-video-effector/build.gradle
+++ b/webrtc-video-effector/build.gradle
@@ -42,6 +42,8 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    // AGP 8.0 からモジュールレベルの build script 内に namespace が必要になった
+    // 参考: https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes#namespace-dsl
     namespace 'jp.shiguredo.webrtc.video.effector'
 }
 

--- a/webrtc-video-effector/build.gradle
+++ b/webrtc-video-effector/build.gradle
@@ -42,6 +42,7 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    namespace 'jp.shiguredo.webrtc.video.effector'
 }
 
 ktlint {
@@ -62,7 +63,7 @@ dependencies {
     } else {
         // external dependency
         api("com.github.shiguredo:sora-android-sdk:${sora_android_sdk_version}") {
-            transitive = true
+            // transitive = true
         }
     }
 

--- a/webrtc-video-effector/src/main/AndroidManifest.xml
+++ b/webrtc-video-effector/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="jp.shiguredo.webrtc.video.effector">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION
- [UPDATE] Android Gradle Plugin (AGP) を 8.5.0 にアップグレードする
  - Android Studion の AGP Upgrade Assistant を利用してアップグレードされた内容
    - `com.android.tools.build:gradle` を 8.5.0 に上げる
    - ビルドに利用される Gradle を 8.7 に上げる
    - Android マニフェストからビルドファイルにパッケージを移動
      - Android マニフェストに定義されていた package を削除
      - ビルドファイルに namespace を追加
    - ビルドファイルの dependencies の transitive をコメントアウト
  - AGP 8.5.0 対応で発生したビルドスクリプトのエラーを手動で修正した内容
    - AGP 8.0 から buildConfig がデフォルト false になったため、true に設定する

---

This pull request includes several updates to upgrade the Android Gradle Plugin (AGP) to version 8.5.0 and make necessary adjustments to the build files and configurations. The most important changes include upgrading the Gradle version, modifying build configurations, and updating namespaces in the build scripts.

### AGP Upgrade and Build Configuration Adjustments:

* [`gradle/wrapper/gradle-wrapper.properties`](diffhunk://#diff-40640fe1078ece83d7ea8fb67daacd77923a86d13447baf9769660b3b46f2eceL3-R3): Upgraded Gradle distribution URL to version 8.7.
* [`samples/build.gradle`](diffhunk://#diff-b28b714c39a482b1d017930d268f29c54aae66058c453beaf0532c5c21730ddeR49-R54): Set `buildConfig` to true because AGP 8.0 defaults it to false, which would otherwise disable `buildConfigField` options.
* [`samples/build.gradle`](diffhunk://#diff-b28b714c39a482b1d017930d268f29c54aae66058c453beaf0532c5c21730ddeR78-R80): Added `namespace` to the module-level build script as required by AGP 8.0.
* [`webrtc-video-effector/build.gradle`](diffhunk://#diff-57f35487cf7e61b39b7f139ac8dad048686404b735568c94d625fce30328cd65R45-R47): Added `namespace` to the module-level build script.

### Manifest and Dependency Updates:

* [`samples/src/main/AndroidManifest.xml`](diffhunk://#diff-b840a80f18e23c1e91a1db051f3e9fe6462222105ed1e6bcab72c108ce471a8dL3-R3): Removed the `package` attribute from the Android manifest.
* [`webrtc-video-effector/build.gradle`](diffhunk://#diff-57f35487cf7e61b39b7f139ac8dad048686404b735568c94d625fce30328cd65L65-R68): Commented out the `transitive` attribute in dependencies.
* [`webrtc-video-effector/src/main/AndroidManifest.xml`](diffhunk://#diff-09bc8d16165b25d5b8ff60ae6a7ba42e0fbd4840ccbd19be136f9b1c8d829de4L1-R1): Removed the `package` attribute from the Android manifest.

These changes ensure compatibility with the latest AGP and Gradle versions, streamline the build process, and adhere to new configuration requirements.