### PR TITLE
依存ライブラリをバージョンアップする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,7 +39,7 @@
   - @zztkm
 - [UPDATE] Kotlin のバージョンを 1.9.25 に上げる
   - 合わせて、kotlinCompilerExtensionVersion を 1.5.15 に上げる
-  - @miosakuma
+  - @zztkm
 
 ## sora-andoroid-sdk-2024.2.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,18 @@
   - AGP 8.5.0 対応で発生したビルドスクリプトのエラーを手動で修正した内容
     - AGP 8.0 から buildConfig がデフォルト false になったため、true に設定する
   - @zztkm
+- [UPDATE] 依存ライブラリーのバージョンを上げる
+  - com.google.code.gson:gson を 2.11.0 に上げる
+  - androidx.appcompat:appcompat を 1.7.0 に上げる
+  - androidx.recyclerview:recyclerview を 1.3.2 に上げる
+  - com.google.android.material:material を 1.12.0 に上げる
+  - androidx.navigation:navigation-fragment-ktx を 2.7.7 に上げる
+  - androidx.navigation:navigation-ui-ktx を 2.7.7 に上げる
+  - androidx.compose.ui:ui を 1.6.8 に上げる
+  - androidx.compose.material:material を 1.6.8 に上げる
+  - androidx.compose.material:material-icons-extended を 1.6.8 に上げる
+  - androidx.activity:activity-compose を 1.9.1 に上げる
+  - @zztkm
 
 ## sora-andoroid-sdk-2024.2.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,9 @@
 - [UPDATE] compileSdkVersion を 34 に上げる
   - Android API レベル 34 以降でコンパイルする必要がある依存ライブラリがあるため
   - @zztkm
+- [UPDATE] Kotlin のバージョンを 1.9.25 に上げる
+  - 合わせて、kotlinCompilerExtensionVersion を 1.5.15 に上げる
+  - @miosakuma
 
 ## sora-andoroid-sdk-2024.2.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,9 @@
   - androidx.compose.material:material-icons-extended を 1.6.8 に上げる
   - androidx.activity:activity-compose を 1.9.1 に上げる
   - @zztkm
+- [UPDATE] compileSdkVersion を 34 に上げる
+  - Android API レベル 34 以降でコンパイルする必要がある依存ライブラリがあるため
+  - @zztkm
 
 ## sora-andoroid-sdk-2024.2.0
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: "com.github.ben-manes.versions"
 
 buildscript {
-    ext.kotlin_version = '1.8.10'
+    ext.kotlin_version = '1.9.25'
     ext.sora_android_sdk_version = 'develop-SNAPSHOT'
 
     repositories {

--- a/samples/build.gradle
+++ b/samples/build.gradle
@@ -100,21 +100,21 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${kotlin_version}"
     implementation "org.jetbrains.kotlin:kotlin-reflect:${kotlin_version}"
 
-    implementation 'com.google.code.gson:gson:2.10.1'
+    implementation 'com.google.code.gson:gson:2.11.0'
 
-    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'androidx.appcompat:appcompat:1.7.0'
     implementation "androidx.cardview:cardview:1.0.0"
-    implementation 'androidx.recyclerview:recyclerview:1.3.0'
+    implementation 'androidx.recyclerview:recyclerview:1.3.2'
 
-    implementation 'com.google.android.material:material:1.8.0'
+    implementation 'com.google.android.material:material:1.12.0'
     implementation 'com.jaredrummler:material-spinner:1.3.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation 'androidx.navigation:navigation-fragment-ktx:2.5.3'
-    implementation 'androidx.navigation:navigation-ui-ktx:2.5.3'
-    implementation 'androidx.compose.ui:ui:1.4.0'
-    implementation 'androidx.compose.material:material:1.4.0'
-    implementation "androidx.compose.material:material-icons-extended:1.4.0"
-    implementation 'androidx.activity:activity-compose:1.7.0'
+    implementation 'androidx.navigation:navigation-fragment-ktx:2.7.7'
+    implementation 'androidx.navigation:navigation-ui-ktx:2.7.7'
+    implementation 'androidx.compose.ui:ui:1.6.8'
+    implementation 'androidx.compose.material:material:1.6.8'
+    implementation 'androidx.compose.material:material-icons-extended:1.6.8'
+    implementation 'androidx.activity:activity-compose:1.9.1'
 
     ext.pd_version = '4.9.2'
     implementation "com.github.permissions-dispatcher:permissionsdispatcher:${pd_version}"

--- a/samples/build.gradle
+++ b/samples/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'org.jlleitschuh.gradle.ktlint'
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
     defaultConfig {
         applicationId "jp.shiguredo.sora.sample"
         targetSdkVersion 33

--- a/samples/build.gradle
+++ b/samples/build.gradle
@@ -55,7 +55,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion '1.4.3'
+        kotlinCompilerExtensionVersion '1.5.15'
     }
 
     buildTypes {


### PR DESCRIPTION
変更内容

- [UPDATE] 依存ライブラリーのバージョンを上げる
  - com.google.code.gson:gson を 2.11.0 に上げる
  - androidx.appcompat:appcompat を 1.7.0 に上げる
  - androidx.recyclerview:recyclerview を 1.3.2 に上げる
  - com.google.android.material:material を 1.12.0 に上げる
  - androidx.navigation:navigation-fragment-ktx を 2.7.7 に上げる
  - androidx.navigation:navigation-ui-ktx を 2.7.7 に上げる
  - androidx.compose.ui:ui を 1.6.8 に上げる
  - androidx.compose.material:material を 1.6.8 に上げる
  - androidx.compose.material:material-icons-extended を 1.6.8 に上げる
  - androidx.activity:activity-compose を 1.9.1 に上げる
- [UPDATE] compileSdkVersion を 34 に上げる
  - Android API レベル 34 以降でコンパイルする必要がある依存ライブラリがあるため
- [UPDATE] Kotlin のバージョンを 1.9.25 に上げる
  - 合わせて、kotlinCompilerExtensionVersion を 1.5.15 に上げる

---

This pull request includes several updates to dependencies, the compile SDK version, and the Kotlin compiler extension version. The changes are primarily aimed at keeping the project up-to-date with the latest versions of libraries and tools.

### Dependency Updates:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R25-R42): Updated multiple dependencies, including `gson`, `appcompat`, `recyclerview`, `material`, `navigation-fragment-ktx`, `navigation-ui-ktx`, `compose.ui`, `compose.material`, `compose.material-icons-extended`, and `activity-compose`.
* [`samples/build.gradle`](diffhunk://#diff-b28b714c39a482b1d017930d268f29c54aae66058c453beaf0532c5c21730ddeL103-R117): Updated the versions of the same dependencies in the `dependencies` section.

### SDK and Compiler Version Updates:

* [`samples/build.gradle`](diffhunk://#diff-b28b714c39a482b1d017930d268f29c54aae66058c453beaf0532c5c21730ddeL7-R7): Changed `compileSdkVersion` from 33 to 34.
* [`samples/build.gradle`](diffhunk://#diff-b28b714c39a482b1d017930d268f29c54aae66058c453beaf0532c5c21730ddeL58-R58): Updated `kotlinCompilerExtensionVersion` from 1.4.3 to 1.5.15.