### PR TITLE
Pixel で1つのアプリをキャストした際の不自然な挙動を改善する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,6 +49,7 @@
   - `Handler ()` は非推奨になっており、現在のスレッドに関連付けられた Looper を利用する事で以下の問題が発生していた
   - スクリーンキャストが正常終了しなかった場合に、SoraScreencastService.closeChannel の処理が main スレッド以外で実行されて `CalledFromWrongThreadException` が発生していした問題を修正した
   - SoraMediaChannel.Listener.onClose の呼び出しにより SoraScreencastService.closeChannel を実行するときに closeChannel 内の Handler() 呼び出しがブロッキングされ、アプリが停止してしまう問題を修正した
+  - @tnoho
 
 ## sora-andoroid-sdk-2024.2.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,13 +11,6 @@
 
 ## develop
 
-- [UPDATE] 1つのアプリをキャストした際の不自然な挙動を改善する
-  - `CalledFromWrongThreadException` が発生する問題を修正
-  - `Could not create virtual display: WebRTC_ScreenCapture` が発生する問題を修正
-  - キャストした画面の映像を飛ばすために、MainActivity に画面更新を促す Intent を送る処理を追加
-    - サンプルアプリは画面内に動きがなく、画面を動かすまで映像が飛ばない問題があったため
-  - Pixel シリーズで動作確認済
-  - @tnoho
 - [UPDATE] Android Gradle Plugin (AGP) を 8.5.0 にアップグレードする
   - Android Studion の AGP Upgrade Assistant を利用してアップグレードされた内容
     - `com.android.tools.build:gradle` を 8.5.0 に上げる
@@ -47,6 +40,15 @@
 - [UPDATE] Kotlin のバージョンを 1.9.25 に上げる
   - 合わせて、kotlinCompilerExtensionVersion を 1.5.15 に上げる
   - @zztkm
+- [UPDATE] 1つのアプリをキャストした際の挙動を改善する
+  - キャストした画面の映像を飛ばすために、MainActivity に画面更新を促す Intent を送る処理を追加
+    - サンプルアプリは画面内に動きがなく、画面を動かすまで映像が飛ばない問題があったため
+  - 動作確認は Android 14 の Pixel シリーズでのみ行っており、他の端末での動作は未確認
+  - @tnoho
+- [FIX] `Handler (Looper looper)` に `getMainLooper()` で取得した、メインスレッドに関連付けられた Looper を利用するように修正する
+  - `Handler ()` は非推奨になっており、現在のスレッドに関連付けられた Looper を利用する事で以下の問題が発生していた
+  - スクリーンキャストが正常終了しなかった場合に、SoraScreencastService.closeChannel の処理が main スレッド以外で実行されて `CalledFromWrongThreadException` が発生していした問題を修正した
+  - SoraMediaChannel.Listener.onClose の呼び出しにより SoraScreencastService.closeChannel を実行するときに closeChannel 内の Handler() 呼び出しがブロッキングされ、アプリが停止してしまう問題を修正した
 
 ## sora-andoroid-sdk-2024.2.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,15 +40,17 @@
 - [UPDATE] Kotlin のバージョンを 1.9.25 に上げる
   - 合わせて、kotlinCompilerExtensionVersion を 1.5.15 に上げる
   - @zztkm
-- [UPDATE] 1つのアプリをキャストした際の挙動を改善する
-  - キャストした画面の映像を飛ばすために、MainActivity に画面更新を促す Intent を送る処理を追加
-    - サンプルアプリは画面内に動きがなく、画面を動かすまで映像が飛ばない問題があったため
-  - 動作確認は Android 14 の Pixel シリーズでのみ行っており、他の端末での動作は未確認
+- [UPDATE] スクリーンキャストサンプルで 1 つのアプリを選択して配信した際の挙動を改善する
+  - スクリーンキャストの映像を送信するために、MainActivity に画面更新を促す Intent を送る処理を追加
+    - スクリーンキャストサンプルは画面内に動きがなく、画面を動かすまで映像が送信されない問題があったため
+  - `Could not create virtual display` というエラーが出て 1 つのアプリでスクリーンキャストできない問題を修正
+    -  SoraScreencastService を起動する Activity タスクを分けることで回避できることがわかったため、`ScreencastSetupActivity` の launchMode を `singleInstance` に変更した
+    - Activity のタスクを分けることに合わせて画面遷移の見直しを行った
+  - 動作確認は Android 14 の Pixel 端末でのみ行っており、他の端末での動作は未確認
   - @tnoho
-- [FIX] `Handler (Looper looper)` に `getMainLooper()` で取得した、メインスレッドに関連付けられた Looper を利用するように修正する
-  - `Handler ()` は非推奨になっており、現在のスレッドに関連付けられた Looper を利用する事で以下の問題が発生していた
-  - スクリーンキャストが正常終了しなかった場合に、SoraScreencastService.closeChannel の処理が main スレッド以外で実行されて `CalledFromWrongThreadException` が発生していした問題を修正した
-  - SoraMediaChannel.Listener.onClose の呼び出しにより SoraScreencastService.closeChannel を実行するときに closeChannel 内の Handler() 呼び出しがブロッキングされ、アプリが停止してしまう問題を修正した
+- [FIX] `Handler ()` で現在のスレッドに関連付けられた Looper を利用するようになっていたことで発生していた以下の問題を `Handler (Looper looper)` に `getMainLooper()` で取得した、メインスレッドに関連付けられた Looper を利用するようにして修正する
+  - スクリーンキャストが正常終了しなかった場合に、`SoraScreencastService.closeChannel()` の処理が main スレッド以外で実行されて `CalledFromWrongThreadException` が発生していた問題
+  - `SoraMediaChannel.Listener.onClose()` の呼び出しにより `SoraScreencastService.closeChannel()` を実行するときに内部の `Handler()` 呼び出しがブロッキングされ、アプリが停止してしまう問題
   - @tnoho
 
 ## sora-andoroid-sdk-2024.2.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,9 +48,12 @@
     - Activity のタスクを分けることに合わせて画面遷移の見直しを行った
   - 動作確認は Android 14 の Pixel 端末でのみ行っており、他の端末での動作は未確認
   - @tnoho
-- [FIX] `Handler ()` で現在のスレッドに関連付けられた Looper を利用するようになっていたことで発生していた以下の問題を `Handler (Looper looper)` に `getMainLooper()` で取得した、メインスレッドに関連付けられた Looper を利用するようにして修正する
-  - スクリーンキャストが正常終了しなかった場合に、`SoraScreencastService.closeChannel()` の処理が main スレッド以外で実行されて `CalledFromWrongThreadException` が発生していた問題
-  - `SoraMediaChannel.Listener.onClose()` の呼び出しにより `SoraScreencastService.closeChannel()` を実行するときに内部の `Handler()` 呼び出しがブロッキングされ、アプリが停止してしまう問題
+- [FIX] `Handler ()` で現在のスレッドに関連付けられた Looper を利用するようになっていたことで発生していた以下の問題を修正する
+  - 発生した問題
+    - スクリーンキャストが正常終了しなかった場合に、`SoraScreencastService.closeChannel()` の処理が main スレッド以外で実行されて `CalledFromWrongThreadException` が発生する
+    - `SoraMediaChannel.Listener.onClose()` の呼び出しにより `SoraScreencastService.closeChannel()` を実行するときに内部の `Handler()` 呼び出しがブロッキングされ、アプリが停止するケースがあった
+  - 修正内容
+   - `Handler (Looper looper)` に `getMainLooper()` で取得した、メインスレッドに関連付けられた Looper を利用するようにした
   - @tnoho
 
 ## sora-andoroid-sdk-2024.2.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,13 @@
 
 ## develop
 
+- [UPDATE] 1つのアプリをキャストした際の不自然な挙動を改善する
+  - `CalledFromWrongThreadException` が発生する問題を修正
+  - `Could not create virtual display: WebRTC_ScreenCapture` が発生する問題を修正
+  - キャストした画面の映像を飛ばすために、MainActivity に画面更新を促す Intent を送る処理を追加
+    - サンプルアプリは画面内に動きがなく、画面を動かすまで映像が飛ばない問題があったため
+  - Pixel シリーズで動作確認済
+  - @tnoho
 - [UPDATE] Android Gradle Plugin (AGP) を 8.5.0 にアップグレードする
   - Android Studion の AGP Upgrade Assistant を利用してアップグレードされた内容
     - `com.android.tools.build:gradle` を 8.5.0 に上げる

--- a/samples/src/main/AndroidManifest.xml
+++ b/samples/src/main/AndroidManifest.xml
@@ -58,11 +58,13 @@
         <!--
             ScreencastSetupActivity は Pixel で1つのアプリにこのサンプル自体を選んだ際に、
             配信が失敗してしまう対策として android:launchMode="singleInstance" としている
+            またサンプルアプリ自体が選択候補に出るように android:taskAffinity を設定している
         -->
         <activity
             android:name=".ui.ScreencastSetupActivity"
             android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout"
             android:label="スクリーンキャスト"
+            android:taskAffinity=".secondary"
             android:launchMode="singleInstance"
             android:exported="true"  />
         <activity

--- a/samples/src/main/AndroidManifest.xml
+++ b/samples/src/main/AndroidManifest.xml
@@ -50,23 +50,27 @@
             android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout"
             android:label="ビデオチャット"
             android:exported="true" />
-
-    <activity
+        <activity
             android:name=".ui.SpotlightRoomSetupActivity"
             android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout"
             android:label="スポットライト"
             android:exported="true" />
+        <!--
+            ScreencastSetupActivity は Pixel で1つのアプリにこのサンプル自体を選んだ際に、
+            配信が失敗してしまう対策として android:launchMode="singleInstance" としている
+        -->
         <activity
             android:name=".ui.ScreencastSetupActivity"
             android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout"
             android:label="スクリーンキャスト"
-            android:exported="true" />
-    <activity
+            android:launchMode="singleInstance"
+            android:exported="true"  />
+        <activity
             android:name=".ui.EffectedVideoChatSetupActivity"
             android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout"
             android:label="ビデオエフェクト"
             android:exported="true" />
-    <activity
+        <activity
             android:name=".ui.SimulcastSetupActivity"
             android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout"
             android:label="サイマルキャスト"
@@ -97,13 +101,11 @@
             android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout"
             android:label="ボイスチャット"
             android:exported="true" />
-
-    <service
+        <service
             android:name=".screencast.SoraScreencastService"
             android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout"
             android:enabled="true"
             android:foregroundServiceType="mediaProjection" />
-
         <activity
             android:name=".ui.EffectedVideoChatActivity"
             android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout"

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/screencast/SoraScreencastService.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/screencast/SoraScreencastService.kt
@@ -217,7 +217,7 @@ class SoraScreencastService : Service() {
         capturer?.let {
             if (capturing) {
                 capturing = false
-                SoraLogger.d(TAG, "startCapture")
+                SoraLogger.d(TAG, "stopCapture")
                 it.stopCapture()
             }
         }

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/screencast/SoraScreencastService.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/screencast/SoraScreencastService.kt
@@ -204,6 +204,7 @@ class SoraScreencastService : Service() {
     private fun sendInvalidateBroadcast() {
         // MainActivity に画面更新を促す Intent を送る
         val intent = Intent("ACTION_INVALIDATE_VIEW")
+        intent.setPackage(applicationContext.packageName)
         sendBroadcast(intent)
     }
 

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/screencast/SoraScreencastService.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/screencast/SoraScreencastService.kt
@@ -12,6 +12,7 @@ import android.media.projection.MediaProjection
 import android.os.Build
 import android.os.Handler
 import android.os.IBinder
+import android.os.Looper
 import android.view.LayoutInflater
 import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
@@ -296,7 +297,7 @@ class SoraScreencastService : Service() {
     }
 
     private fun closeChannel() {
-        val handler = Handler()
+        val handler = Handler(Looper.getMainLooper())
         handler.post {
             SoraLogger.d(TAG, "closeChannel")
             mediaChannel?.disconnect()

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/screencast/SoraScreencastService.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/screencast/SoraScreencastService.kt
@@ -56,6 +56,9 @@ class SoraScreencastService : Service() {
 
         override fun onConnect(mediaChannel: SoraMediaChannel) {
             SoraLogger.d(TAG, "[screencast] @onConnected")
+            // MainActivity に画面更新を促す Intent を送る
+            // 取れるイベントの中では最も遅いが、このタイミングでも送信が開始されているとは限らない
+            sendInvalidateBroadcast()
         }
 
         override fun onClose(mediaChannel: SoraMediaChannel) {
@@ -198,12 +201,24 @@ class SoraScreencastService : Service() {
         }
     }
 
+    private fun sendInvalidateBroadcast() {
+        // MainActivity に画面更新を促す Intent を送る
+        val intent = Intent("ACTION_INVALIDATE_VIEW")
+        sendBroadcast(intent)
+    }
+
     internal fun startCapturer() {
         capturer?.let {
             if (!capturing) {
                 capturing = true
                 SoraLogger.d(TAG, "startCapture")
                 val size = SoraScreenUtil.size(this)
+                /*
+                 * Pixel シリーズにおいてキャスト時に 1つのアプリ でこのサンプルを選び、
+                 * 下記の処理を呼び出した場合は失敗してしまう。
+                 * それに対する対策として ScreencastSetupActivity を
+                 * android:launchMode="singleInstance" にしている
+                 */
                 it.startCapture(
                     Math.round(size.x * req!!.videoScale),
                     Math.round(size.y * req!!.videoScale),

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/screencast/SoraScreencastServiceStarter.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/screencast/SoraScreencastServiceStarter.kt
@@ -101,6 +101,11 @@ class SoraScreencastServiceStarter(
         )
         intent.putExtra("SCREENCAST_REQUEST", request)
         activity.startService(intent)
+        /*
+         * startService を行った Activity は1つのアプリにもなれないので、
+         * アプリ切り替えにも現れないよう finishAndRemoveTask でタスクごと消す
+         */
+        activity.finishAndRemoveTask()
         return true
     }
 }

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/ScreencastSetupActivity.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/ScreencastSetupActivity.kt
@@ -4,7 +4,6 @@ import android.annotation.TargetApi
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
-import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.snackbar.Snackbar
 import com.jaredrummler.materialspinner.MaterialSpinner
@@ -51,6 +50,21 @@ class ScreencastSetupActivity : AppCompatActivity() {
         }
     }
 
+    override fun onResume() {
+        super.onResume()
+
+        /*
+         * 1つのアプリ にこのサンプル以外を選んだ場合にはこの Activity が再表示されてしまい、
+         * 他のアプリを選んだ場合と一貫性がないので、 SoraScreencastService が動作中の場合は
+         * MainActivity に戻す
+         */
+        if (SoraScreencastService.isRunning()) {
+            val intent = Intent(this, MainActivity::class.java)
+            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            startActivity(intent)
+        }
+    }
+
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         screencastStarter?.onActivityResult(requestCode, resultCode, data)
@@ -91,22 +105,10 @@ class ScreencastSetupActivity : AppCompatActivity() {
             serviceClass = SoraScreencastService::class
         )
         screencastStarter?.start()
-        showNavigationMessage()
-    }
-
-    private fun showNavigationMessage() {
-        AlertDialog.Builder(this)
-            .setPositiveButton("OK") { _, _ -> goToHome() }
-            .setCancelable(false)
-            .setMessage("スクリーンキャストを終了するときは上のナビゲーションバーから終了ボタンを押してください。")
-            .show()
-    }
-
-    private fun goToHome() {
-        val intent = Intent(Intent.ACTION_MAIN)
-        intent.addCategory(Intent.CATEGORY_HOME)
-        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
-        startActivity(intent)
+        /*
+         * 1つのアプリ をスクリーンキャスト時にはここに下に何か書いても、
+         * すでに選ばれたアプリに遷移しているためユーザーの視界に入ることはない
+         */
     }
 
     private fun selectedItem(spinner: MaterialSpinner): String {

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/ScreencastSetupActivity.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/ScreencastSetupActivity.kt
@@ -50,21 +50,6 @@ class ScreencastSetupActivity : AppCompatActivity() {
         }
     }
 
-    override fun onResume() {
-        super.onResume()
-
-        /*
-         * 1つのアプリ にこのサンプル以外を選んだ場合にはこの Activity が再表示されてしまい、
-         * 他のアプリを選んだ場合と一貫性がないので、 SoraScreencastService が動作中の場合は
-         * MainActivity に戻す
-         */
-        if (SoraScreencastService.isRunning()) {
-            val intent = Intent(this, MainActivity::class.java)
-            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
-            startActivity(intent)
-        }
-    }
-
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         screencastStarter?.onActivityResult(requestCode, resultCode, data)


### PR DESCRIPTION
Google Pixel でスクリーンキャストを行う際に**1つのアプリ**にこのサンプル自体を選択した場合にログに `Could not create virtual display` と表示され配信が行われなくなってしまう問題を改善します。

根本的な原因としてはログの通り `createVirtualDisplay` に失敗しているため発生しています。これを回避するためには `SoraScreencastService` を起動する Activity のタスクを分けることで回避できることがわかりました。

タスクを分けてしまうため Service を起動する Activity 自体を配信することができないという問題はそのままですが、 Service を起動する Activity をダイアログ的な扱いをする画面遷移設計することでユーザーが違和感なく使えるようにしてあります。

プランA では下記のブランチで1つのアプリ選択において、下部のアイコン一覧のみにサンプルアプリが表示されます。
https://github.com/shiguredo/sora-android-sdk-samples/tree/feature/fix-screencast

このPRのプランBブランチでは下部のアイコン一覧だけでなく、自身のアプリが上部の画面選択に表示されます。

どちらの解決策を取るかは実装するアプリの用途次第かと思うので、2種類実装してみました。
なお、 AndroidManifest で Activity の属性を変える必要があるため、もし両方の実装をアプリに入れる場合は Activity を分割する必要があります。

ちなみに1つのアプリにすると制御用のオーバーレイが配信映像に入らないのは素敵だなと思いました。