### PR TITLE
GitHub Actions の定期実行をやめる

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,6 @@ on:
       - 'CHANGES.md'
       - 'LICENSE'
       - 'THANKS'
-  schedule:
-    - cron: "0 0 * * *"
 
 jobs:
   build:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,9 @@
 
 ### misc
 
+- [UPDATE] GitHub Actions の定期実行をやめる
+  - @zztkm
+
 ## sora-andoroid-sdk-2025.1.0
 
 **リリース日**: 2025-01-27


### PR DESCRIPTION
- [UPDATE] GitHub Actions の定期実行をやめる

---

This pull request includes changes to the build workflow and updates the `CHANGES.md` file to reflect these changes. The most important changes include the removal of the scheduled GitHub Actions workflow and the corresponding update in the change log.

Changes to build workflow:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L10-L11): Removed the scheduled GitHub Actions workflow by deleting the `schedule` section.

Updates to change log:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R16-R18): Added an entry to document the removal of the scheduled GitHub Actions workflow.