### PR TITLE
依存ライブラリ、targetSdkVersion、Android Gradle Plugin のアップデート

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,31 @@
 
 ## develop
 
+- [UPDATE] 依存ライブラリーのバージョンを上げる
+  - com.google.code.gson:gson を 2.13.1 に上げる
+  - androidx.appcompat:appcompat を 1.7.1 に上げる
+  - androidx.recyclerview:recyclerview を 1.4.0 に上げる
+  - androidx.constraintlayout:constraintlayout を 2.2.1 に上げる
+  - androidx.navigation:navigation-fragment-ktx を 2.9.3 に上げる
+  - androidx.navigation:navigation-ui-ktx を 2.9.3 に上げる
+  - androidx.compose.ui:ui を 1.8.3 に上げる
+  - androidx.compose.material:material を 1.8.3 に上げる
+  - androidx.compose.material:material-icons-extended を 1.7.8 に上げる
+  - androidx.activity:activity-compose を 1.10.1 に上げる
+  - com.android.tools.build:gradle を 8.11.1 に上げる
+  - Gradle を 8.14.3 に上げる
+  - compileSdkVersion を 36 に上げる
+  - targetSdkVersion を 36 に上げる
+  - @miosakuma
+- [UPDATE] edge-to-edge の画面表示に対応する
+  - targetSdkVersion 35 以降 edge-to-edge の画面表示がデフォルトとなった
+  - 各画面レイアウト に `android:fitsSystemWindows="true"` を指定する
+  - バックグラウンドカラーを白以外にしてステータスバーの文字が見えるようにする
+  - @miosakuma
+- [UPDATE] 権限に FOREGROUND_SERVICE_MEDIA_PROJECTION を追加する 
+  - スクリーンキャストのサービスを起動するために必要な権限
+  - Android 14 (API level 34) 以降で必要になる
+  - @miosakuma
 - [UPDATE] ビデオエフェクトサンプルを削除する
   - `jp.co.cyberagent.android:gpuimage:2.1.0` が 16 KB ページサイズに対応していないため
   - @miosakuma

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,7 @@
 - [UPDATE] edge-to-edge の画面表示に対応する
   - targetSdkVersion 35 以降 edge-to-edge の画面表示がデフォルトとなった
   - 各画面レイアウト に `android:fitsSystemWindows="true"` を指定する
+  - リアルタイムメッセージングサンプルのコンポーザブルに systemBarsPadding() を設定する
   - バックグラウンドカラーを白以外にしてステータスバーの文字が見えるようにする
   - @miosakuma
 - [UPDATE] 権限に FOREGROUND_SERVICE_MEDIA_PROJECTION を追加する 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ apply plugin: "com.github.ben-manes.versions"
 
 buildscript {
     ext.kotlin_version = '1.9.25'
-    ext.sora_android_sdk_version = '2025.2.0-canary.12'
+    ext.sora_android_sdk_version = '2025.2.0-canary.14'
 
     repositories {
         google()
@@ -10,7 +10,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.5.0'
+        classpath 'com.android.tools.build:gradle:8.11.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Jan 20 16:14:02 JST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/build.gradle
+++ b/samples/build.gradle
@@ -4,10 +4,10 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'org.jlleitschuh.gradle.ktlint'
 
 android {
-    compileSdkVersion 34
+    compileSdkVersion 36
     defaultConfig {
         applicationId "jp.shiguredo.sora.sample"
-        targetSdkVersion 33
+        targetSdkVersion 36
         minSdkVersion 26
         versionCode 1
         versionName "1.0"
@@ -102,21 +102,21 @@ dependencies {
 
     implementation "com.github.shiguredo:sora-android-sdk:${sora_android_sdk_version}"
 
-    implementation 'com.google.code.gson:gson:2.11.0'
+    implementation 'com.google.code.gson:gson:2.13.1'
 
-    implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'androidx.appcompat:appcompat:1.7.1'
     implementation "androidx.cardview:cardview:1.0.0"
-    implementation 'androidx.recyclerview:recyclerview:1.3.2'
+    implementation 'androidx.recyclerview:recyclerview:1.4.0'
 
     implementation 'com.google.android.material:material:1.12.0'
     implementation 'com.jaredrummler:material-spinner:1.3.1'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation 'androidx.navigation:navigation-fragment-ktx:2.7.7'
-    implementation 'androidx.navigation:navigation-ui-ktx:2.7.7'
-    implementation 'androidx.compose.ui:ui:1.6.8'
-    implementation 'androidx.compose.material:material:1.6.8'
-    implementation 'androidx.compose.material:material-icons-extended:1.6.8'
-    implementation 'androidx.activity:activity-compose:1.9.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
+    implementation 'androidx.navigation:navigation-fragment-ktx:2.9.3'
+    implementation 'androidx.navigation:navigation-ui-ktx:2.9.3'
+    implementation 'androidx.compose.ui:ui:1.8.3'
+    implementation 'androidx.compose.material:material:1.8.3'
+    implementation 'androidx.compose.material:material-icons-extended:1.7.8'
+    implementation 'androidx.activity:activity-compose:1.10.1'
 
     ext.pd_version = '4.9.2'
     implementation "com.github.permissions-dispatcher:permissionsdispatcher:${pd_version}"

--- a/samples/src/main/AndroidManifest.xml
+++ b/samples/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
     <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
 
     <uses-feature android:name="android.hardware.camera2.full" />
     <uses-feature android:name="android.hardware.camera" />

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/MessagingActivity.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/MessagingActivity.kt
@@ -625,7 +625,8 @@ fun TopComposable(channel: SoraMessagingChannel) {
     val labels = remember { mutableStateListOf<String>() }
     val messages = remember { mutableStateListOf<Message>() }
 
-    // ステータスバーやナビゲーションバーに重ならないように、システムバーのパディングを設定する
+    // targetSdkVersion 35 以降 edge-to-edge の画面表示がデフォルトになったため、
+    // ステータスバーやナビゲーションバーに重ならないように、明示的にシステムバーのパディングを設定する必要がある
     Box(modifier = Modifier.systemBarsPadding()) {
         if (connected) {
             TimelineComposable(channel, setConnected, labels, messages, listState)

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/MessagingActivity.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/MessagingActivity.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
@@ -624,10 +625,12 @@ fun TopComposable(channel: SoraMessagingChannel) {
     val labels = remember { mutableStateListOf<String>() }
     val messages = remember { mutableStateListOf<Message>() }
 
-    if (connected) {
-        TimelineComposable(channel, setConnected, labels, messages, listState)
-    } else {
-        SetupComposable(channel, defaultChannelId, setConnected, labels, messages)
+    Box(modifier = Modifier.systemBarsPadding()) {
+        if (connected) {
+            TimelineComposable(channel, setConnected, labels, messages, listState)
+        } else {
+            SetupComposable(channel, defaultChannelId, setConnected, labels, messages)
+        }
     }
 }
 

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/MessagingActivity.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/ui/MessagingActivity.kt
@@ -625,6 +625,7 @@ fun TopComposable(channel: SoraMessagingChannel) {
     val labels = remember { mutableStateListOf<String>() }
     val messages = remember { mutableStateListOf<Message>() }
 
+    // ステータスバーやナビゲーションバーに重ならないように、システムバーのパディングを設定する
     Box(modifier = Modifier.systemBarsPadding()) {
         if (connected) {
             TimelineComposable(channel, setConnected, labels, messages, listState)

--- a/samples/src/main/res/layout/activity_main.xml
+++ b/samples/src/main/res/layout/activity_main.xml
@@ -5,6 +5,7 @@
     android:layout_height="match_parent"
     android:background="@drawable/app_background"
     android:orientation="vertical"
+    android:fitsSystemWindows="true"
     android:padding="6dp">
 
     <androidx.recyclerview.widget.RecyclerView

--- a/samples/src/main/res/layout/activity_screencast_setup.xml
+++ b/samples/src/main/res/layout/activity_screencast_setup.xml
@@ -4,7 +4,9 @@
     android:id="@+id/rootLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:background="@drawable/app_background"
+    android:orientation="vertical"
+    android:fitsSystemWindows="true">
 
     <ScrollView
         android:layout_width="match_parent"

--- a/samples/src/main/res/layout/activity_simulcast.xml
+++ b/samples/src/main/res/layout/activity_simulcast.xml
@@ -5,6 +5,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical"
     android:background="@android:color/black"
+    android:fitsSystemWindows="true"
     android:padding="10dp">
 
     <LinearLayout

--- a/samples/src/main/res/layout/activity_simulcast_setup.xml
+++ b/samples/src/main/res/layout/activity_simulcast_setup.xml
@@ -3,7 +3,9 @@
     android:id="@+id/rootLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:background="@drawable/app_background"
+    android:orientation="vertical"
+    android:fitsSystemWindows="true">
 
     <ScrollView
         android:layout_width="match_parent"

--- a/samples/src/main/res/layout/activity_spotlight_room_setup.xml
+++ b/samples/src/main/res/layout/activity_spotlight_room_setup.xml
@@ -4,7 +4,9 @@
     android:id="@+id/rootLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:background="@drawable/app_background"
+    android:orientation="vertical"
+    android:fitsSystemWindows="true">
 
     <ScrollView
         android:layout_width="match_parent"

--- a/samples/src/main/res/layout/activity_video_chat_room.xml
+++ b/samples/src/main/res/layout/activity_video_chat_room.xml
@@ -5,6 +5,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical"
     android:background="@android:color/black"
+    android:fitsSystemWindows="true"
     android:padding="10dp">
 
     <LinearLayout

--- a/samples/src/main/res/layout/activity_video_chat_room_setup.xml
+++ b/samples/src/main/res/layout/activity_video_chat_room_setup.xml
@@ -4,7 +4,9 @@
     android:id="@+id/rootLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:background="@drawable/app_background"
+    android:orientation="vertical"
+    android:fitsSystemWindows="true">
 
     <ScrollView
         android:layout_width="match_parent"

--- a/samples/src/main/res/layout/activity_voice_chat_room.xml
+++ b/samples/src/main/res/layout/activity_voice_chat_room.xml
@@ -5,6 +5,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical"
     android:background="@android:color/black"
+    android:fitsSystemWindows="true"
     android:padding="20dp">
 
     <LinearLayout

--- a/samples/src/main/res/layout/activity_voice_chat_room_setup.xml
+++ b/samples/src/main/res/layout/activity_voice_chat_room_setup.xml
@@ -4,7 +4,9 @@
     android:id="@+id/rootLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:background="@drawable/app_background"
+    android:orientation="vertical"
+    android:fitsSystemWindows="true">
 
     <ScrollView
         android:layout_width="match_parent"


### PR DESCRIPTION
- [UPDATE] 依存ライブラリーのバージョンを上げる
  - com.google.code.gson:gson を 2.13.1 に上げる
  - androidx.appcompat:appcompat を 1.7.1 に上げる
  - androidx.recyclerview:recyclerview を 1.4.0 に上げる
  - androidx.constraintlayout:constraintlayout を 2.2.1 に上げる
  - androidx.navigation:navigation-fragment-ktx を 2.9.3 に上げる
  - androidx.navigation:navigation-ui-ktx を 2.9.3 に上げる
  - androidx.compose.ui:ui を 1.8.3 に上げる
  - androidx.compose.material:material を 1.8.3 に上げる
  - androidx.compose.material:material-icons-extended を 1.7.8 に上げる
  - androidx.activity:activity-compose を 1.10.1 に上げる
  - com.android.tools.build:gradle を 8.11.1 に上げる
  - Gradle を 8.14.3 に上げる
  - compileSdkVersion を 36 に上げる
  - targetSdkVersion を 36 に上げる
- [UPDATE] edge-to-edge の画面表示に対応する
  - targetSdkVersion 35 以降 edge-to-edge の画面表示がデフォルトとなった
  - 各画面レイアウト に `android:fitsSystemWindows="true"` を指定する
  - リアルタイムメッセージングサンプルのコンポーザブルに systemBarsPadding() を設定する
  - バックグラウンドカラーを白以外にしてステータスバーの文字が見えるようにする
- [UPDATE] 権限に FOREGROUND_SERVICE_MEDIA_PROJECTION を追加する 
  - スクリーンキャストのサービスを起動するために必要な権限
  - Android 14 (API level 34) 以降で必要になる
