### PR TITLE
ローカルビルドの設定を追加する

### DIFF
--- a/samples/build.gradle
+++ b/samples/build.gradle
@@ -100,8 +100,6 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${kotlin_version}"
     implementation "org.jetbrains.kotlin:kotlin-reflect:${kotlin_version}"
 
-    implementation "com.github.shiguredo:sora-android-sdk:${sora_android_sdk_version}"
-
     implementation 'com.google.code.gson:gson:2.13.1'
 
     implementation 'androidx.appcompat:appcompat:1.7.1'
@@ -121,6 +119,17 @@ dependencies {
     ext.pd_version = '4.9.2'
     implementation "com.github.permissions-dispatcher:permissionsdispatcher:${pd_version}"
     kapt "com.github.permissions-dispatcher:permissionsdispatcher-processor:${pd_version}"
+
+    // Sora Android SDK
+    if (findProject(':sora-android-sdk') != null) {
+        // module is included
+        api project(':sora-android-sdk')
+    } else {
+        // external dependency
+        implementation("com.github.shiguredo:sora-android-sdk:${sora_android_sdk_version}@aar") {
+            transitive = true
+        }
+    }
 }
 
 repositories {


### PR DESCRIPTION
ビデオエフェクトサンプル削除時の build.gradle の移行ミスについて対応しています。
ローカルでサブプロジェクトして動作する設定を消してしまっていたので復帰させました。

この修正でローカルで sora-android-sdk から sora-android-sdk-samples をサブプロジェクトとして取り込めるようになります。
 
移行元のソース
https://github.com/shiguredo/sora-android-sdk-samples/pull/88/files#diff-57f35487cf7e61b39b7f139ac8dad048686404b735568c94d625fce30328cd65L60-L70