### PR TITLE
2025.2.0-canary.17 にあげる

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,8 @@
 - [UPDATE] Sora Android SDK を 2025.2.0 にあげる
   - onError(SoraMediaChannel, SoraErrorReason) の廃止に対応する
   - onClose(mediaChannel: SoraMediaChannel) から onClose(mediaChannel: SoraMediaChannel, closeEvent: SoraCloseEvent) へ移行する
+  - CameraCapturerFactory.create() の引数から fixedResolution を削除する
+    - fixedResolution の値は false 固定であったため単純削除しても動作に変更はない
   - @miosakuma
 - [UPDATE] ビデオチャットサンプル、サイマルキャストサンプル、スポットライトサンプルの映像コーデックに `未指定` を追加する
   - @miosakuma

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ apply plugin: "com.github.ben-manes.versions"
 
 buildscript {
     ext.kotlin_version = '1.9.25'
-    ext.sora_android_sdk_version = '2025.2.0-canary.16'
+    ext.sora_android_sdk_version = '2025.2.0-canary.17'
 
     repositories {
         google()

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/camera/CameraVideoCapturerFactory.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/camera/CameraVideoCapturerFactory.kt
@@ -17,6 +17,6 @@ class DefaultCameraVideoCapturerFactory(
 ) : CameraVideoCapturerFactory {
 
     override fun createCapturer(): CameraVideoCapturer? {
-        return CameraCapturerFactory.create(context, fixedResolution, frontFacingFirst)
+        return CameraCapturerFactory.create(context, frontFacingFirst)
     }
 }


### PR DESCRIPTION
- CameraCapturerFactory.create() の引数から fixedResolution を削除する
  - fixedResolution の値は false 固定であったため単純削除しても動作に変更はない