### PR TITLE
onOfferMessage を onSignalingMessage に置き換える

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,13 @@
 - FIX
   - バグ修正
 
+## 2026.2
+
+- [UPDATE] Sora Android SDK を 2026.2.0-canary.0 に上げる
+  - @zztkm
+- [UPDATE] Video チャットサンプルで `onOfferMessage` を `onSignalingMessage` に置き換える
+  - @zztkm
+
 ## 2026.1
 
 - [CHANGE] サイマルキャストの設定値である SimulcastRid を SimulcastRequestRid に移行する

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ jvmTarget = "1.8"
 javaCompatibility = "1.8"
 
 # Sora SDK
-sora-android-sdk = "2026.1.0"
+sora-android-sdk = "2026.2.0-canary.0"
 
 # Libraries
 gson = "2.13.1"

--- a/samples/src/main/kotlin/jp/shiguredo/sora/sample/facade/SoraVideoChannel.kt
+++ b/samples/src/main/kotlin/jp/shiguredo/sora/sample/facade/SoraVideoChannel.kt
@@ -12,6 +12,8 @@ import jp.shiguredo.sora.sample.stats.VideoUpstreamLatencyStatsCollector
 import jp.shiguredo.sora.sample.ui.util.SoraRemoteRendererSlot
 import jp.shiguredo.sora.sdk.channel.SoraCloseEvent
 import jp.shiguredo.sora.sdk.channel.SoraMediaChannel
+import jp.shiguredo.sora.sdk.channel.SoraSignalingDirection
+import jp.shiguredo.sora.sdk.channel.SoraSignalingTransportType
 import jp.shiguredo.sora.sdk.channel.data.ChannelAttendeesCount
 import jp.shiguredo.sora.sdk.channel.option.PeerConnectionOption
 import jp.shiguredo.sora.sdk.channel.option.SoraAudioOption
@@ -21,7 +23,6 @@ import jp.shiguredo.sora.sdk.channel.option.SoraVideoOption
 import jp.shiguredo.sora.sdk.channel.rpc.SoraRpcException
 import jp.shiguredo.sora.sdk.channel.rpc.SoraRpcResult
 import jp.shiguredo.sora.sdk.channel.signaling.message.NotificationMessage
-import jp.shiguredo.sora.sdk.channel.signaling.message.OfferMessage
 import jp.shiguredo.sora.sdk.channel.signaling.message.PushMessage
 import jp.shiguredo.sora.sdk.error.SoraErrorReason
 import jp.shiguredo.sora.sdk.util.SoraLogger
@@ -273,11 +274,16 @@ class SoraVideoChannel(
                 }
             }
 
-            override fun onOfferMessage(
+            override fun onSignalingMessage(
                 mediaChannel: SoraMediaChannel,
-                offer: OfferMessage,
+                direction: SoraSignalingDirection,
+                transportType: SoraSignalingTransportType,
+                rawMessage: String,
             ) {
-                SoraLogger.d(TAG, "[video_channel] @onOfferMessage $offer")
+                SoraLogger.d(
+                    TAG,
+                    "[video_channel] @onSignalingMessage direction=$direction transportType=$transportType message=$rawMessage",
+                )
             }
 
             override fun onNotificationMessage(


### PR DESCRIPTION
## 概要
- Sora Android SDK を `2026.2.0-canary.0` に更新
- Video チャットサンプルの `onOfferMessage` を `onSignalingMessage` に置き換え
- 変更履歴 (`CHANGES.md`) に 2026.2 の更新内容を追加

## 動作確認
- `./gradlew :samples:ktlintCheck`
